### PR TITLE
ci: add CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+# CodeQL static analysis (SAST) for the JS/TS sources. Complements the OpenSSF
+# Scorecard and qScan self-scan; satisfies Scorecard's SAST criterion. Actions
+# are pinned by SHA to match the repo-wide supply-chain policy.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write # upload CodeQL results to the Security tab
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/github-packages.yml
+++ b/.github/workflows/github-packages.yml
@@ -17,12 +17,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   container-ghcr:
     name: Push the MCP server image to ghcr.io
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -45,6 +47,9 @@ jobs:
   npm-github-packages:
     name: Publish npm packages to GitHub Packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Adds a CodeQL analysis workflow for the JS/TS sources, satisfying the OpenSSF Scorecard SAST criterion. Actions pinned by SHA per the repo supply-chain policy; minimal permissions (top-level contents:read, job-level security-events:write).