### PR TITLE
fix(security): resolve CodeQL findings in untrusted-input paths

### DIFF
--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -260,7 +260,7 @@ export function authorizeRequest(
 ): AuthDecision {
   if (token.length === 0) return { authorized: true };
   const header = (authorizationHeader ?? "").trim();
-  const match = /^Bearer\s+(.+)$/i.exec(header);
+  const match = /^Bearer\s+(\S.*)$/i.exec(header);
   const presented = match?.[1]?.trim();
   if (!presented) {
     return { authorized: false, status: 401, message: "missing bearer token" };

--- a/packages/qprobe/src/mlkem768.ts
+++ b/packages/qprobe/src/mlkem768.ts
@@ -46,14 +46,26 @@ export function byteDecode12(bytes: Buffer): number[] {
   return out;
 }
 
-/** A random polynomial with all coefficients in [0, q) (throwaway, not uniform). */
+/** A random polynomial with all coefficients uniform in [0, q) (throwaway probe key). */
 function randomInRangePoly(): number[] {
-  const raw = randomBytes(N * 2);
+  // Rejection sampling from 16-bit draws to avoid modulo bias. The key is a
+  // throwaway (never used for real security), but a security tool should not
+  // ship biased "randomness" even here.
+  const MAX = Math.floor(0x10000 / ML_KEM_Q) * ML_KEM_Q;
   const poly: number[] = new Array(N);
+  let pool = randomBytes(N * 4);
+  let off = 0;
   for (let i = 0; i < N; i++) {
-    // 16-bit sample reduced mod q — biased but always in [0, q), which is all the
-    // server's modulus check requires. This is a throwaway key.
-    poly[i] = raw.readUInt16BE(i * 2) % ML_KEM_Q;
+    let v: number;
+    do {
+      if (off + 2 > pool.length) {
+        pool = randomBytes(N * 4);
+        off = 0;
+      }
+      v = pool.readUInt16BE(off);
+      off += 2;
+    } while (v >= MAX);
+    poly[i] = v % ML_KEM_Q;
   }
   return poly;
 }

--- a/packages/sieve/src/protocol.ts
+++ b/packages/sieve/src/protocol.ts
@@ -283,7 +283,12 @@ export function toB64(bytes: Uint8Array): string {
 export function fromB64(b64: string): Uint8Array {
   const buf = Buffer.from(b64, "base64");
   // Buffer.from is lenient; sanity-check by re-encoding the canonical form.
-  if (buf.toString("base64").replace(/=+$/, "") !== b64.replace(/\s/g, "").replace(/=+$/, "")) {
+  const trimEq = (x: string): string => {
+    let n = x.length;
+    while (n > 0 && x[n - 1] === "=") n--;
+    return x.slice(0, n);
+  };
+  if (trimEq(buf.toString("base64")) !== trimEq(b64.replace(/\s/g, ""))) {
     throw new ProtocolError("invalid base64", b64);
   }
   return new Uint8Array(buf);


### PR DESCRIPTION
Fixes the CodeQL findings that sit on attacker-controlled input:
- **biased-cryptographic-random** (qProbe ML-KEM probe key): now unbiased rejection sampling. It is a throwaway key, but a crypto tool should not sample biased randomness.
- **polynomial-redos** in Sieve `fromB64` (parses untrusted system-under-test output) and MCP bearer-token parsing (untrusted auth header): both O(n^2) regexes replaced with linear equivalents.

216 tests pass, including the fuzz tests on the patched parsers. The remaining trailing-slash-trim findings (walk glob patterns, agent baseURL) are on trusted config input and are dismissed separately.