### PR TITLE
Observatory: internal PQC-readiness probe worker (ADR 0007)

### DIFF
--- a/docs/adr/0007-observatory-probing-policy.md
+++ b/docs/adr/0007-observatory-probing-policy.md
@@ -1,0 +1,104 @@
+# 0007 - Observatory: restrained probing of hosts we do not own
+
+- **Status:** Accepted
+- **Date:** 2026-07-25
+- **Deciders:** quantakrypto-tools maintainers
+- **Supersedes / Superseded by:** -
+
+## Context
+
+qProbe (`@quantakrypto/qprobe`) actively inspects live TLS/SSH endpoints for
+post-quantum readiness. By design its public entry point `runProbe` calls
+`authorizeTargets(...)` first: an ownership-attestation gate that throws before any
+socket is opened (see `packages/qprobe/THREAT-MODEL.md` and ADR-0005). That gate is
+correct for qProbe's job, which is to probe infrastructure the operator owns.
+
+We also want an aggregate, longitudinal view of the public web's post-quantum TLS
+posture: what fraction of notable hosts have turned on the X25519MLKEM768 hybrid key
+exchange, and how that share moves month over month. That measurement is only
+meaningful across hosts we do NOT own (major sites, CDNs, cloud and PKI vendors).
+Running it through `runProbe` is impossible by construction, and would be wrong to
+try: we cannot attest ownership of `google.com`.
+
+## Decision
+
+Build the observatory as an INTERNAL, unpublished worker (`packages/observatory`,
+`private: true`) that deliberately bypasses the ownership gate, and constrain it with
+a restrained probing policy enforced in code, not merely documented.
+
+**Gate bypass, done narrowly.** The worker does not call `runProbe` and does not
+weaken it. It reuses qProbe's lower-level, un-gated primitives by internal source
+import: `probeHybridSupport` (raw ClientHello advertising X25519MLKEM768, to see
+whether the server SELECTS the hybrid group) and `extractNegotiated` (reads the
+negotiated version / cipher / KEX group and the leaf-cert signature family from a
+connected socket). We reuse `extractNegotiated` rather than `probeTlsNegotiated`
+because the latter discards its socket before returning and we also need the leaf
+cert's `notAfter`; the observatory opens the one handshake and reads `valid_to` from
+the same peer certificate. No qProbe source is modified, and its public API and
+ownership gate are untouched: the observatory simply does not go through the front
+door that the gate guards.
+
+**Restrained probing policy (all enforced in `src/probe.ts` / `src/run.ts`):**
+
+- One probe cycle per host per run. A cycle is at most two short-lived, read-only
+  handshakes (one TLS handshake for the negotiated posture + cert, one raw
+  ClientHello for hybrid support). No content is fetched beyond the handshake.
+- A hard per-connection timeout (8s default).
+- A minimum interval between hosts (500ms default). Hosts are probed sequentially;
+  there is no parallel fan-out.
+- Connection refusals and timeouts are recorded as `reachable = false` and never
+  retried. A failed host is simply unreachable this cycle.
+- Read-only always. We inspect the negotiated reality and disconnect; we never
+  modify, authenticate to, or exploit an endpoint. `rejectUnauthorized` is off
+  because we inspect posture, not assert trust.
+- Opt-out is honored within one cycle: any domain in `optout.txt` (or marked
+  `opted_out_at` in the database, e.g. by the website) is recorded and then skipped
+  in the same run, before any connection to it is attempted.
+
+The seed host list (`hosts.txt`) is committed and reviewable, scoped to notable
+public endpoints. Results and a monthly rollup are written to Postgres
+(`observatory_host` / `observatory_probe` / `observatory_rollup`), whose schema the
+website owns; the worker only `CREATE TABLE IF NOT EXISTS`es them defensively and
+upserts idempotently per `run_month`.
+
+## Legal and ethical posture
+
+An unauthenticated, single TLS handshake to a public host on port 443 is ordinary,
+industry-normal internet measurement. It is exactly what a browser does to reach the
+site, and it is the same class of read-only observation performed at scale by
+long-standing public services such as Qualys SSL Labs and Censys. We read only what
+the server volunteers during the handshake (negotiated parameters and the
+certificate it presents); we do not authenticate, we do not send application data, we
+do not probe non-standard ports, and we do not attempt any exploit. Combined with the
+restraint above (one gentle cycle, spacing, no retries, honored opt-out), this keeps
+the observatory within the normal-measurement envelope. The opt-out list is the
+explicit, low-friction way for any operator to be excluded, honored within a cycle.
+
+## Consequences
+
+**Easier:** a truthful, repeatable public-posture metric that composes with the rest
+of the toolchain's PQC framing; a standalone worker that runs from the committed seed
+list with only `DATABASE_URL` and `pg`.
+
+**Harder / costs accepted:** the observatory reuses qProbe internals by relative
+source import, so a refactor of `packages/qprobe/src/tls.ts` (specifically
+`extractNegotiated` / `probeHybridSupport`) can break it; this is the accepted price
+of not widening qProbe's public surface or its gate. `pg` is a new dependency, scoped
+as a devDependency of this private package only, so the published packages keep the
+ADR-0001 zero-runtime-dependency invariant.
+
+**Operations:** the worker runs on the existing dl-latest VM (no separate VM for now),
+on a monthly cadence (`observatory run --month YYYY-MM`). Scheduling (cron / systemd
+timer) and the `DATABASE_URL` secret are provisioned on that VM.
+
+## Alternatives considered
+
+- **Add an "observatory" mode to the public qProbe CLI.** Rejected: it would either
+  route unowned hosts through the ownership gate (impossible) or add a public path
+  that skips the gate (erodes the THREAT-MODEL invariant the gate exists to hold).
+  Keeping the bypass in a private, unpublished worker confines it.
+- **Relax `authorizeTargets` to allow a "public measurement" flag.** Rejected: it
+  weakens a security boundary of a published tool to serve an internal need.
+- **Re-implement the handshake probes from scratch in the observatory.** Rejected:
+  needless duplication of audited byte-level code (the ClientHello codec, the
+  negotiated-field and cert-signature extraction) that qProbe already maintains.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ Format: a lightweight [MADR](https://adr.github.io/madr/)-style record.
 | [0004](0004-sieve-no-fabricated-vectors.md) | Sieve ships no KAT vectors and never fabricates expected values | Accepted |
 | [0005](0005-byok-agent-two-planes.md) | BYOK agent line: `@quantakrypto/agent` is the sole networked plane; the engine disposes | Accepted |
 | [0006](0006-report-output-english-only.md) | Human-facing report output is English-only (no i18n) | Accepted |
+| [0007](0007-observatory-probing-policy.md) | Observatory: restrained probing of hosts we do not own | Accepted |
 
 ## Related governance
 

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# OpenSSF Best Practices badge - pre-filled answers
+
+Answer sheet for the [OpenSSF Best Practices](https://www.bestpractices.dev) (formerly CII) **passing** badge for `quantakrypto/pqc-tools`. Register the project at bestpractices.dev (sign in with GitHub, add `https://github.com/quantakrypto/pqc-tools`), then use the evidence below to answer each criterion. Almost every criterion is already **Met**.
+
+When done, paste the badge markdown into `README.md` and Scorecard's CII-Best-Practices check goes green.
+
+Legend: **Met** / **N/A** / *Unmet (action)*.
+
+## Basics
+| Criterion | Answer | Evidence |
+|---|---|---|
+| description_good | Met | `README.md` describes the toolkit (qScan, Sieve, qProbe, MCP, action). |
+| interact / discussion | Met | GitHub Issues + Discussions enabled. |
+| contribution | Met | `CONTRIBUTING.md`. |
+| contribution_requirements | Met | `CONTRIBUTING.md` states PR + tests + lint requirements. |
+| floss_license / _osi | Met | Apache-2.0 (OSI-approved); `package.json` `"license": "Apache-2.0"`, `REUSE.toml` `path="**"`. |
+| license_location | Met | `LICENSE` at repo root. |
+| documentation_basics | Met | `README.md` + `docs/` (API, CONFIG, VERSIONING, THREAT-MODEL, SUPPLY-CHAIN, COMPLIANCE, ADRs). |
+| documentation_interface | Met | `docs/API.md`, per-package READMEs, generated `api-surface.json`. |
+| sites_https | Met | GitHub + npm are HTTPS. |
+| english | Met | All docs in English. |
+| maintained | Met | Active commit history; Dependabot + CI. |
+
+## Change control
+| Criterion | Answer | Evidence |
+|---|---|---|
+| repo_public / repo_track / repo_distributed | Met | Public Git repo on GitHub. |
+| version_unique / version_semver | Met | Per-package semver; policy in `docs/VERSIONING.md`. |
+| version_tags | Met | Git tags + GitHub Releases; `v1` action tag. |
+| release_notes | Met | `CHANGELOG.md`. |
+| release_notes_vulns | Met | `CHANGELOG.md` records security-relevant fixes (e.g., the recent ReDoS / sampling fixes). |
+
+## Reporting
+| Criterion | Answer | Evidence |
+|---|---|---|
+| report_process / report_tracker / report_archive | Met | GitHub Issues (public, archived). |
+| report_responses / enhancement_responses | Met | Maintainers triage issues/PRs. |
+| vulnerability_report_process | Met | `SECURITY.md` → **security@quantakrypto.com** + GitHub private vulnerability reporting; follows ISO/IEC 29147 + 30111. |
+| vulnerability_report_private | Met | `SECURITY.md` documents private reporting (email + GitHub "Report a vulnerability"). |
+| vulnerability_report_response | Met | `SECURITY.md` commits to a plan within 10 business days. |
+
+## Quality
+| Criterion | Answer | Evidence |
+|---|---|---|
+| build / build_common_tools / build_floss_tools | Met | `npm run build` (`tsc --build`); FLOSS toolchain. |
+| test / test_invocation | Met | `npm test` (Node built-in test runner; `packages/*/test/*.test.ts` + `scripts/test`). |
+| test_most | Met | Broad unit tests + property-based fuzz tests (fast-check) on the parsers. |
+| test_continuous_integration | Met | `.github/workflows/ci.yml` runs build + test + lint on every PR and push (required status checks). |
+| test_policy / tests_are_added / tests_documented_added | Met | `CONTRIBUTING.md` requires tests for new functionality; enforced in review. |
+| warnings / warnings_fixed / warnings_strict | Met | ESLint (`npm run lint`) + strict `tsconfig`; CI "lint + format" gate blocks on warnings. |
+
+## Security
+| Criterion | Answer | Evidence |
+|---|---|---|
+| know_secure_design / know_common_errors | Met | `docs/THREAT-MODEL.md`, ADRs, and the team builds PQC security tooling; CodeQL + Scorecard + qScan self-scan in CI. |
+| crypto_published | Met | Uses NIST-standardized algorithms (FIPS 203/204/205) and Node's `crypto`; no home-grown primitives. |
+| crypto_call / crypto_floss | Met | Cryptographic operations use Node.js `crypto` (FLOSS, widely reviewed). |
+| crypto_keylength | Met | Standard parameter sets (e.g., ML-KEM-768); no undersized keys. |
+| crypto_working / crypto_weaknesses | Met | No broken algorithms used for security (MD5/SHA-1 appear only as *detection targets*, not in the tool's own security). |
+| crypto_random | Met | `crypto.randomBytes`; the ML-KEM probe key uses unbiased rejection sampling. |
+| crypto_pfs | N/A | Not a network service establishing long-lived sessions; qProbe is a read-only client, hosted MCP TLS is terminated by the platform. |
+| crypto_password_storage / crypto_certificate_verification | N/A | No password storage. qProbe deliberately does not verify certs (it inspects posture, documented). |
+| delivery_mitm / delivery_unsigned | Met | npm over HTTPS **with provenance** (Sigstore/OIDC in `release.yml`); GitHub Actions pinned by commit SHA (`scripts/check-action-pins.mjs`). |
+| vulnerabilities_fixed_60_days / vulnerabilities_critical_fixed | Met | Dependabot enabled; recent High alerts (js-yaml, brace-expansion) fixed promptly. |
+| no_leaked_credentials | Met | GitHub secret scanning enabled; no secrets committed. |
+
+## Analysis
+| Criterion | Answer | Evidence |
+|---|---|---|
+| static_analysis / _common_vulnerabilities | Met | CodeQL (`.github/workflows/codeql.yml`), ESLint, OpenSSF Scorecard, and qScan self-scan (dogfood) all run in CI. |
+| static_analysis_fixed | Met | CodeQL findings triaged: real ones fixed, by-design ones dismissed with reasons. |
+| static_analysis_often | Met | CodeQL runs on every push/PR + weekly schedule. |
+| dynamic_analysis | Met | Property-based fuzzing (fast-check) of the untrusted-input parsers (qProbe TLS/SSH/X.509, Sieve protocol). |
+| dynamic_analysis_unsafe | N/A | TypeScript/JavaScript (memory-safe); no unsafe-language analysis needed. |
+| dynamic_analysis_enable_assertions | Met | Tests assert invariants; fuzz properties assert robustness contracts. |
+
+---
+Net: every **MUST** for the passing badge is satisfied. Register, confirm each row above, and add the badge to `README.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -754,6 +754,10 @@
       "resolved": "packages/mcp",
       "link": true
     },
+    "node_modules/@quantakrypto/observatory": {
+      "resolved": "packages/observatory",
+      "link": true
+    },
     "node_modules/@quantakrypto/qprobe": {
       "resolved": "packages/qprobe",
       "link": true
@@ -788,6 +792,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1888,6 +1904,103 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -1899,6 +2012,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -1998,6 +2154,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2169,6 +2335,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2226,6 +2402,18 @@
       },
       "bin": {
         "quantakrypto-mcp": "dist/stdio.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/observatory": {
+      "name": "@quantakrypto/observatory",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/pg": "^8.11.10",
+        "pg": "^8.13.1"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "qscan": "node --import tsx packages/qscan/src/cli.ts"
+    "qscan": "node --import tsx packages/qscan/src/cli.ts",
+    "observatory": "node --import tsx packages/observatory/src/cli.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/packages/observatory/hosts.txt
+++ b/packages/observatory/hosts.txt
@@ -1,0 +1,98 @@
+# PQC observatory seed host list.
+#
+# One host per line, probed on port 443. Lines beginning with `#` and blank
+# lines are ignored. Line order is the host's rank (first line = rank 1), used
+# only to bucket the monthly rollup; it is not a claim of real-world traffic
+# rank. Keep this list to notable, publicly reachable endpoints (major sites,
+# CDNs, cloud providers, a few security/PKI vendors). To exclude a host without
+# deleting it, add it to optout.txt instead.
+#
+# Probing policy (enforced in code, see docs/adr/0007-observatory-probing-policy.md):
+# one connection cycle per host per run, an 8s hard timeout, a >=500ms gap
+# between hosts, no aggressive retries, and opt-out honored within one cycle.
+
+# --- Major consumer sites ---
+google.com
+youtube.com
+facebook.com
+instagram.com
+x.com
+linkedin.com
+wikipedia.org
+reddit.com
+amazon.com
+apple.com
+microsoft.com
+netflix.com
+ebay.com
+yahoo.com
+bing.com
+duckduckgo.com
+spotify.com
+twitch.tv
+discord.com
+telegram.org
+
+# --- Developer / platform ---
+github.com
+gitlab.com
+stackoverflow.com
+npmjs.com
+nodejs.org
+python.org
+kernel.org
+debian.org
+ubuntu.com
+mozilla.org
+
+# --- Cloud / hosting / SaaS ---
+amazonaws.com
+cloud.google.com
+azure.microsoft.com
+digitalocean.com
+heroku.com
+vercel.com
+netlify.com
+wordpress.com
+shopify.com
+salesforce.com
+oracle.com
+ibm.com
+adobe.com
+dropbox.com
+slack.com
+zoom.us
+
+# --- CDN / edge / DNS ---
+cloudflare.com
+akamai.com
+fastly.com
+cloudflare-dns.com
+
+# --- Payments / commerce ---
+stripe.com
+paypal.com
+
+# --- News / media ---
+cnn.com
+bbc.com
+nytimes.com
+theguardian.com
+
+# --- Security / identity / PKI vendors ---
+letsencrypt.org
+digicert.com
+sectigo.com
+globalsign.com
+okta.com
+auth0.com
+crowdstrike.com
+paloaltonetworks.com
+fortinet.com
+signal.org
+proton.me
+
+# --- Internet-measurement / research ---
+censys.io
+shodan.io
+ssllabs.com

--- a/packages/observatory/optout.txt
+++ b/packages/observatory/optout.txt
@@ -1,0 +1,12 @@
+# PQC observatory opt-out list.
+#
+# One host per line. Any domain listed here is:
+#   1. recorded in observatory_host with opted_out_at set, and
+#   2. never probed (skipped within the same run it is added to).
+#
+# This is how an operator removes a host from active probing within one cycle,
+# per docs/adr/0007-observatory-probing-policy.md, without editing hosts.txt.
+# `#` comments and blank lines are ignored.
+#
+# Example:
+# example.com

--- a/packages/observatory/package.json
+++ b/packages/observatory/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@quantakrypto/observatory",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Internal PQC observatory probe worker. Measures post-quantum TLS readiness (X25519MLKEM768 hybrid KEX, negotiated version/cipher, leaf-cert signature + expiry) across a committed list of notable public hosts and writes monthly rollups to Postgres. NOT published; NOT a mode of the public qProbe CLI; deliberately bypasses qProbe's ownership gate (see docs/adr/0007-observatory-probing-policy.md).",
+  "license": "Apache-2.0",
+  "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "observatory": "node --import tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.10",
+    "pg": "^8.13.1"
+  }
+}

--- a/packages/observatory/src/cli.ts
+++ b/packages/observatory/src/cli.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Observatory CLI. Thin shell over `run` in `./run.ts`: parse argv, print, exit.
+ *
+ *   observatory run [--month YYYY-MM] [--hosts PATH] [--optout PATH]
+ *                   [--timeout MS] [--interval MS] [--dry-run]
+ *
+ * When --month is omitted the month is OBS_MONTH, else the current UTC month
+ * (computed inside `run`, never at module load). DATABASE_URL is read from the
+ * environment; --dry-run probes without writing to Postgres.
+ */
+import process from "node:process";
+
+import { run } from "./run.js";
+
+const HELP = `observatory - internal PQC readiness prober (not a published tool)
+
+Usage:
+  observatory run [options]
+
+Options:
+  --month YYYY-MM    Run month (default: OBS_MONTH env, else current UTC month)
+  --hosts PATH       Seed host list (default: packages/observatory/hosts.txt)
+  --optout PATH      Opt-out list  (default: packages/observatory/optout.txt)
+  --timeout MS       Per-connection hard timeout (default: 8000)
+  --interval MS      Minimum gap between hosts (default: 500)
+  --dry-run          Probe only; do not connect to or write Postgres
+  -h, --help         Show this help
+
+Environment:
+  DATABASE_URL       Postgres connection string (required unless --dry-run)
+  OBS_MONTH          Fallback run month when --month is not given
+`;
+
+interface Parsed {
+  help: boolean;
+  month?: string;
+  hostsFile?: string;
+  optoutFile?: string;
+  timeoutMs?: number;
+  minIntervalMs?: number;
+  dryRun: boolean;
+}
+
+function parseInteger(flag: string, value: string | undefined): number {
+  if (value === undefined) throw new Error(`${flag} requires a value`);
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) throw new Error(`${flag} must be a non-negative number`);
+  return n;
+}
+
+function parseArgs(argv: readonly string[]): Parsed {
+  const out: Parsed = { help: false, dryRun: false };
+  // First non-flag token is the subcommand; only `run` is supported.
+  const args = [...argv];
+  const sub = args.find((a) => !a.startsWith("-"));
+  if (sub && sub !== "run") throw new Error(`unknown command "${sub}" (only "run")`);
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    switch (a) {
+      case "run":
+        break;
+      case "-h":
+      case "--help":
+        out.help = true;
+        break;
+      case "--dry-run":
+        out.dryRun = true;
+        break;
+      case "--month":
+        out.month = args[++i];
+        break;
+      case "--hosts":
+        out.hostsFile = args[++i];
+        break;
+      case "--optout":
+        out.optoutFile = args[++i];
+        break;
+      case "--timeout":
+        out.timeoutMs = parseInteger("--timeout", args[++i]);
+        break;
+      case "--interval":
+        out.minIntervalMs = parseInteger("--interval", args[++i]);
+        break;
+      default:
+        if (a.startsWith("-")) throw new Error(`unknown option "${a}"`);
+    }
+  }
+  return out;
+}
+
+async function main(argv: readonly string[]): Promise<number> {
+  let parsed: Parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`observatory: ${(err as Error).message}\n`);
+    process.stderr.write(`Run "observatory --help" for usage.\n`);
+    return 2;
+  }
+  if (parsed.help || argv.length === 0) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  try {
+    const summary = await run({
+      month: parsed.month,
+      hostsFile: parsed.hostsFile,
+      optoutFile: parsed.optoutFile,
+      timeoutMs: parsed.timeoutMs,
+      minIntervalMs: parsed.minIntervalMs,
+      dryRun: parsed.dryRun,
+    });
+    process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+    return 0;
+  } catch (err) {
+    process.stderr.write(`observatory: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+main(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`observatory: fatal ${String(err)}\n`);
+    process.exit(1);
+  },
+);

--- a/packages/observatory/src/db.ts
+++ b/packages/observatory/src/db.ts
@@ -1,0 +1,216 @@
+/**
+ * Postgres persistence for the observatory.
+ *
+ * The three tables are OWNED by the website's migration; this worker only ever
+ * CREATE TABLE IF NOT EXISTS them (defensively, so it can run standalone) and
+ * upserts rows. It never drops or alters them, so a run against a DB the website
+ * already migrated is a no-op on the schema and a plain upsert on the data.
+ *
+ * `pg` is the observatory's ONLY third-party dependency, and it is a devDependency
+ * of this private package alone; the published qProbe / qScan / core packages stay
+ * zero-dependency (ADR-0001).
+ */
+import { Client } from "pg";
+
+import type { SeedHost } from "./hosts.js";
+import type { HostMeasurement } from "./probe.js";
+
+/** Exact schema from the website migration, guarded with IF NOT EXISTS. */
+export const SCHEMA_DDL = `
+CREATE TABLE IF NOT EXISTS observatory_host (
+  id text PRIMARY KEY, domain text UNIQUE NOT NULL, rank_source text,
+  rank int, added_at timestamptz NOT NULL DEFAULT now(), opted_out_at timestamptz);
+CREATE TABLE IF NOT EXISTS observatory_probe (
+  id text PRIMARY KEY, host_id text NOT NULL REFERENCES observatory_host(id) ON DELETE CASCADE,
+  run_month text NOT NULL, reachable boolean NOT NULL DEFAULT false,
+  kex_hybrid boolean NOT NULL DEFAULT false, kex_group text, tls_version text,
+  cert_sig_alg text, cert_expiry timestamptz, probed_at timestamptz NOT NULL DEFAULT now(),
+  raw jsonb NOT NULL DEFAULT '{}'::jsonb, UNIQUE (host_id, run_month));
+CREATE TABLE IF NOT EXISTS observatory_rollup (
+  run_month text PRIMARY KEY, hosts_probed int NOT NULL, pct_hybrid_kex numeric NOT NULL,
+  by_rank_bucket jsonb NOT NULL DEFAULT '{}'::jsonb, generated_at timestamptz NOT NULL DEFAULT now());
+`;
+
+export interface HostRow {
+  id: string;
+  optedOut: boolean;
+  rank: number | null;
+}
+
+export interface RollupBucket {
+  hosts_probed: number;
+  reachable: number;
+  hybrid: number;
+  pct_hybrid_kex: number;
+}
+
+export interface RollupResult {
+  runMonth: string;
+  hostsProbed: number;
+  reachable: number;
+  hybrid: number;
+  pctHybridKex: number;
+  byRankBucket: Record<string, RollupBucket>;
+}
+
+/** Open a client from `DATABASE_URL` (or an explicit override) and connect. */
+export async function openDb(databaseUrl: string): Promise<Client> {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  return client;
+}
+
+/** Create the three tables if they do not already exist. Never alters existing tables. */
+export async function ensureSchema(client: Client): Promise<void> {
+  await client.query(SCHEMA_DDL);
+}
+
+/**
+ * Upsert the seed hosts. New rows are inserted (ON CONFLICT (domain) DO NOTHING so
+ * we never clobber a website-owned row). Opt-out is then applied by a separate
+ * UPDATE so a host that already existed still gets `opted_out_at` set within this
+ * run. Opt-out is sticky: we never clear `opted_out_at` for a host dropped from the
+ * opt-out list (removing a host from probing is intentional and stays until an
+ * operator clears it in the DB).
+ */
+export async function upsertHosts(
+  client: Client,
+  seeds: SeedHost[],
+  optout: Set<string>,
+): Promise<void> {
+  for (const s of seeds) {
+    const optedOutAt = optout.has(s.domain) ? new Date().toISOString() : null;
+    await client.query(
+      `INSERT INTO observatory_host (id, domain, rank_source, rank, opted_out_at)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (domain) DO NOTHING`,
+      [s.domain, s.domain, s.rankSource, s.rank, optedOutAt],
+    );
+  }
+  // Any opt-out domain (seed or already present) that is not yet marked: mark it now.
+  const optoutList = [...optout];
+  if (optoutList.length > 0) {
+    await client.query(
+      `UPDATE observatory_host SET opted_out_at = now()
+       WHERE domain = ANY($1::text[]) AND opted_out_at IS NULL`,
+      [optoutList],
+    );
+  }
+}
+
+/** Read the canonical id / opt-out state / rank for each domain. */
+export async function fetchHostRows(
+  client: Client,
+  domains: string[],
+): Promise<Map<string, HostRow>> {
+  const map = new Map<string, HostRow>();
+  if (domains.length === 0) return map;
+  const res = await client.query(
+    `SELECT id, domain, rank, opted_out_at FROM observatory_host WHERE domain = ANY($1::text[])`,
+    [domains],
+  );
+  for (const r of res.rows as Array<{
+    id: string;
+    domain: string;
+    rank: number | null;
+    opted_out_at: Date | null;
+  }>) {
+    map.set(r.domain, { id: r.id, optedOut: r.opted_out_at !== null, rank: r.rank });
+  }
+  return map;
+}
+
+/** Insert or update the probe row for (host, month). Idempotent per month. */
+export async function upsertProbe(
+  client: Client,
+  hostId: string,
+  runMonth: string,
+  m: HostMeasurement,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO observatory_probe
+       (id, host_id, run_month, reachable, kex_hybrid, kex_group, tls_version,
+        cert_sig_alg, cert_expiry, probed_at, raw)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), $10::jsonb)
+     ON CONFLICT (host_id, run_month) DO UPDATE SET
+       reachable = EXCLUDED.reachable,
+       kex_hybrid = EXCLUDED.kex_hybrid,
+       kex_group = EXCLUDED.kex_group,
+       tls_version = EXCLUDED.tls_version,
+       cert_sig_alg = EXCLUDED.cert_sig_alg,
+       cert_expiry = EXCLUDED.cert_expiry,
+       probed_at = now(),
+       raw = EXCLUDED.raw`,
+    [
+      `${hostId}:${runMonth}`,
+      hostId,
+      runMonth,
+      m.reachable,
+      m.kexHybrid,
+      m.kexGroup ?? null,
+      m.tlsVersion ?? null,
+      m.certSigAlg ?? null,
+      m.certExpiry ?? null,
+      JSON.stringify(m.raw),
+    ],
+  );
+}
+
+/** Rank -> bucket label. Buckets are coarse on purpose (small seed list). */
+function rankBucket(rank: number | null): string {
+  if (rank === null) return "unranked";
+  if (rank <= 25) return "1-25";
+  if (rank <= 50) return "26-50";
+  return "51+";
+}
+
+/**
+ * Recompute the month's rollup from `observatory_probe` joined to host rank, then
+ * upsert `observatory_rollup`. `pct_hybrid_kex` is the share of REACHABLE hosts that
+ * selected the hybrid group (unreachable hosts are excluded from the denominator).
+ */
+export async function computeRollup(client: Client, runMonth: string): Promise<RollupResult> {
+  const res = await client.query(
+    `SELECT h.rank AS rank, p.reachable AS reachable, p.kex_hybrid AS kex_hybrid
+       FROM observatory_probe p
+       JOIN observatory_host h ON h.id = p.host_id
+      WHERE p.run_month = $1`,
+    [runMonth],
+  );
+  const rows = res.rows as Array<{ rank: number | null; reachable: boolean; kex_hybrid: boolean }>;
+
+  const buckets: Record<string, RollupBucket> = {};
+  let hostsProbed = 0;
+  let reachable = 0;
+  let hybrid = 0;
+  for (const row of rows) {
+    hostsProbed += 1;
+    const label = rankBucket(row.rank);
+    const b = (buckets[label] ??= { hosts_probed: 0, reachable: 0, hybrid: 0, pct_hybrid_kex: 0 });
+    b.hosts_probed += 1;
+    if (row.reachable) {
+      reachable += 1;
+      b.reachable += 1;
+      if (row.kex_hybrid) {
+        hybrid += 1;
+        b.hybrid += 1;
+      }
+    }
+  }
+  const pct = (n: number, d: number): number => (d > 0 ? Math.round((n / d) * 10000) / 100 : 0);
+  for (const b of Object.values(buckets)) b.pct_hybrid_kex = pct(b.hybrid, b.reachable);
+  const pctHybridKex = pct(hybrid, reachable);
+
+  await client.query(
+    `INSERT INTO observatory_rollup (run_month, hosts_probed, pct_hybrid_kex, by_rank_bucket, generated_at)
+     VALUES ($1, $2, $3, $4::jsonb, now())
+     ON CONFLICT (run_month) DO UPDATE SET
+       hosts_probed = EXCLUDED.hosts_probed,
+       pct_hybrid_kex = EXCLUDED.pct_hybrid_kex,
+       by_rank_bucket = EXCLUDED.by_rank_bucket,
+       generated_at = now()`,
+    [runMonth, hostsProbed, pctHybridKex, JSON.stringify(buckets)],
+  );
+
+  return { runMonth, hostsProbed, reachable, hybrid, pctHybridKex, byRankBucket: buckets };
+}

--- a/packages/observatory/src/hosts.ts
+++ b/packages/observatory/src/hosts.ts
@@ -1,0 +1,42 @@
+/**
+ * Seed / opt-out list parsing. Pure file + string work over Node built-ins.
+ *
+ * `hosts.txt` is the committed seed list: one domain per line, `#` comments and
+ * blank lines ignored. A host's rank is its 1-based position among the
+ * non-comment lines (used only to bucket the rollup, not a traffic claim).
+ * `optout.txt` has the same line format and names domains that must never be
+ * probed (and are recorded with `opted_out_at`).
+ */
+import { existsSync, readFileSync } from "node:fs";
+
+export interface SeedHost {
+  domain: string;
+  rank: number;
+  rankSource: string;
+}
+
+/** Read a list file into its non-comment, non-blank, lower-cased domains (in order). */
+export function parseHostFile(path: string): string[] {
+  if (!existsSync(path)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    // Strip an inline `# comment`, then trim.
+    const line = raw.replace(/#.*$/, "").trim().toLowerCase();
+    if (line === "") continue;
+    if (seen.has(line)) continue; // de-dup defensively
+    seen.add(line);
+    out.push(line);
+  }
+  return out;
+}
+
+/** Load the seed list, assigning each domain its 1-based line rank. */
+export function loadSeedHosts(path: string, rankSource = "seed"): SeedHost[] {
+  return parseHostFile(path).map((domain, i) => ({ domain, rank: i + 1, rankSource }));
+}
+
+/** Load the opt-out domains (empty when the file is absent). */
+export function loadOptOut(path: string): string[] {
+  return parseHostFile(path);
+}

--- a/packages/observatory/src/probe.ts
+++ b/packages/observatory/src/probe.ts
@@ -1,0 +1,144 @@
+/**
+ * Per-host TLS measurement for the observatory.
+ *
+ * The observatory probes public hosts we do NOT own, so it must NOT use qProbe's
+ * public `runProbe`, which calls `authorizeTargets(...)` (an ownership-attestation
+ * gate) before any network I/O. Instead we reuse qProbe's LOWER-LEVEL, un-gated
+ * primitives directly from its source module:
+ *
+ *   - `probeHybridSupport` - sends a raw ClientHello advertising X25519MLKEM768 and
+ *     reports whether the server SELECTS the hybrid group (positive PQC-hybrid proof).
+ *   - `extractNegotiated` - reads the negotiated TLS version / cipher / KEX group and
+ *     the leaf-cert signature family from an already-connected TLSSocket.
+ *
+ * We deliberately do NOT use `probeTlsNegotiated`: it discards the socket (and thus
+ * the certificate validity window) before returning, and we need the leaf cert's
+ * `notAfter`. To stay within one handshake we open the TLS socket here, delegate all
+ * field extraction to qProbe's `extractNegotiated`, and additionally read `valid_to`
+ * from the same peer certificate. No qProbe source is modified.
+ *
+ * These imports are by RELATIVE PATH into qProbe's `src/` on purpose: the primitives
+ * are not re-exported from the package's public barrel (that barrel intentionally
+ * exposes only `runProbe` for network I/O), and this worker lives in the same
+ * monorepo, so an internal source import is the correct, gate-preserving way in.
+ */
+import { connect as tlsConnect } from "node:tls";
+import {
+  extractNegotiated,
+  probeHybridSupport,
+  type HybridSupport,
+  type TlsNegotiated,
+} from "../../qprobe/src/tls.js";
+
+/** X25519MLKEM768 hybrid group name recorded when the server selects it. */
+const HYBRID_GROUP_NAME = "X25519MLKEM768";
+
+export interface HostMeasurement {
+  /** TCP+TLS handshake completed (the host answered). */
+  reachable: boolean;
+  /** True only when the server SELECTED X25519MLKEM768 (proof of hybrid support). */
+  kexHybrid: boolean;
+  /** Key-exchange group actually in use: the hybrid name, or the classical group. */
+  kexGroup?: string;
+  /** Negotiated protocol, e.g. "TLSv1.3". */
+  tlsVersion?: string;
+  /** Negotiated cipher suite standard name. */
+  cipher?: string;
+  /** Leaf-cert signature family (RSA / ECDSA / EdDSA / DSA) or raw OID fallback. */
+  certSigAlg?: string;
+  /** Leaf-cert `notAfter` as an ISO-8601 string, when readable. */
+  certExpiry?: string;
+  /** First error observed (timeout / refusal / handshake failure); undefined when reachable. */
+  error?: string;
+  /** Raw sub-results, persisted to `observatory_probe.raw` for later forensics. */
+  raw: {
+    negotiated: TlsNegotiated;
+    hybrid: HybridSupport;
+    certNotAfterRaw?: string;
+  };
+}
+
+interface TlsRead {
+  negotiated: TlsNegotiated;
+  certNotAfterRaw?: string;
+}
+
+/**
+ * One normal TLS handshake, reusing qProbe's `extractNegotiated` for the negotiated
+ * fields and additionally reading the leaf cert's `valid_to`. Read-only: we inspect
+ * the negotiated reality and disconnect; we never modify the endpoint. Never rejects.
+ */
+function readTls(host: string, port: number, timeoutMs: number): Promise<TlsRead> {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (r: TlsRead): void => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve(r);
+    };
+    // SNI must not be an IP literal (RFC 6066); omit it for bare IPs.
+    const isIp = /^\d+\.\d+\.\d+\.\d+$/.test(host) || host.includes(":");
+    const servername = isIp ? undefined : host;
+    const socket = tlsConnect({
+      host,
+      port,
+      servername,
+      rejectUnauthorized: false, // we inspect posture; we do not assert trust
+      minVersion: "TLSv1.2",
+    });
+    socket.setTimeout(timeoutMs);
+    socket.on("timeout", () => finish({ negotiated: { error: "timeout" } }));
+    socket.on("error", (e: Error) => finish({ negotiated: { error: e.message } }));
+    socket.on("secureConnect", () => {
+      const negotiated = extractNegotiated(socket);
+      const cert = socket.getPeerCertificate(false);
+      const validTo = cert && typeof cert.valid_to === "string" ? cert.valid_to : undefined;
+      finish({ negotiated, certNotAfterRaw: validTo });
+    });
+  });
+}
+
+/** Parse an OpenSSL-style `valid_to` ("Jun  1 12:00:00 2035 GMT") to ISO, if valid. */
+function toIsoExpiry(validTo: string | undefined): string | undefined {
+  if (!validTo) return undefined;
+  const d = new Date(validTo);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+/**
+ * Measure one host on port 443: negotiated TLS + leaf-cert posture (one handshake)
+ * and hybrid-KEX support (one raw ClientHello). Two short-lived, read-only
+ * handshakes, no retries. Never throws: a refusal or timeout resolves to
+ * `reachable: false`.
+ */
+export async function measureHost(
+  host: string,
+  opts: { port?: number; timeoutMs?: number } = {},
+): Promise<HostMeasurement> {
+  const port = opts.port ?? 443;
+  const timeoutMs = opts.timeoutMs ?? 8000;
+
+  const tls = await readTls(host, port, timeoutMs);
+  const hybrid = await probeHybridSupport(host, port, { timeoutMs });
+
+  const reachable = tls.negotiated.error === undefined;
+  const kexHybrid = hybrid.hybridSelected === true;
+  const certExpiry = toIsoExpiry(tls.certNotAfterRaw);
+
+  return {
+    reachable,
+    kexHybrid,
+    kexGroup: kexHybrid ? HYBRID_GROUP_NAME : tls.negotiated.kexGroup,
+    tlsVersion: tls.negotiated.protocol,
+    cipher: tls.negotiated.cipher,
+    certSigAlg: tls.negotiated.certSigFamily ?? tls.negotiated.certSigOid,
+    certExpiry,
+    error: tls.negotiated.error,
+    raw: {
+      negotiated: tls.negotiated,
+      hybrid,
+      certNotAfterRaw: tls.certNotAfterRaw,
+    },
+  };
+}

--- a/packages/observatory/src/run.ts
+++ b/packages/observatory/src/run.ts
@@ -1,0 +1,167 @@
+/**
+ * Observatory run orchestration: resolve the month, load the seed + opt-out lists,
+ * probe each host under the restrained policy, and persist results + the monthly
+ * rollup. All wall-clock reads happen INSIDE `run` (never at module load), so the
+ * default month is deterministic per invocation and easy to override in tests.
+ */
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  computeRollup,
+  ensureSchema,
+  fetchHostRows,
+  openDb,
+  upsertHosts,
+  upsertProbe,
+} from "./db.js";
+import { loadOptOut, loadSeedHosts, type SeedHost } from "./hosts.js";
+import { measureHost } from "./probe.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** Package root (one level up from src/). */
+const PKG_ROOT = resolve(HERE, "..");
+
+export interface RunOptions {
+  /** Explicit YYYY-MM. When omitted: OBS_MONTH env, else derived from `now`. */
+  month?: string;
+  /** Injected clock for the default-month path; defaults to `new Date()` inside run. */
+  now?: Date;
+  hostsFile?: string;
+  optoutFile?: string;
+  timeoutMs?: number;
+  /** Minimum gap between successive host probes (politeness / restraint). */
+  minIntervalMs?: number;
+  /** Probe only; do not touch Postgres. */
+  dryRun?: boolean;
+  /** DATABASE_URL override; defaults to `process.env.DATABASE_URL`. */
+  databaseUrl?: string;
+  /** Sink for progress lines (defaults to stderr). */
+  log?: (line: string) => void;
+}
+
+export interface RunSummary {
+  runMonth: string;
+  totalSeed: number;
+  optedOut: number;
+  probed: number;
+  reachable: number;
+  hybrid: number;
+  pctHybridKex: number;
+  dryRun: boolean;
+}
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Validate/derive the run month as YYYY-MM. */
+export function resolveMonth(opts: Pick<RunOptions, "month" | "now">): string {
+  const explicit = opts.month ?? process.env.OBS_MONTH;
+  if (explicit) {
+    if (!/^\d{4}-\d{2}$/.test(explicit)) {
+      throw new Error(`invalid --month "${explicit}": expected YYYY-MM`);
+    }
+    return explicit;
+  }
+  const d = opts.now ?? new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+/** Run the observatory for one month. Never throws on a single host's failure. */
+export async function run(opts: RunOptions = {}): Promise<RunSummary> {
+  const log = opts.log ?? ((line: string): void => void process.stderr.write(line + "\n"));
+  const runMonth = resolveMonth(opts);
+  const timeoutMs = opts.timeoutMs ?? 8000;
+  const minIntervalMs = opts.minIntervalMs ?? 500;
+  const dryRun = opts.dryRun ?? false;
+
+  const hostsFile = opts.hostsFile ?? join(PKG_ROOT, "hosts.txt");
+  const optoutFile = opts.optoutFile ?? join(PKG_ROOT, "optout.txt");
+
+  const seeds: SeedHost[] = loadSeedHosts(hostsFile);
+  const optout = new Set(loadOptOut(optoutFile));
+  if (seeds.length === 0) throw new Error(`no seed hosts found in ${hostsFile}`);
+
+  log(
+    `observatory: month=${runMonth} seed=${seeds.length} opt-out=${optout.size} dryRun=${dryRun}`,
+  );
+
+  const databaseUrl = opts.databaseUrl ?? process.env.DATABASE_URL;
+  if (!dryRun && !databaseUrl) {
+    throw new Error("DATABASE_URL is not set (use --dry-run to probe without writing)");
+  }
+
+  const client = !dryRun && databaseUrl ? await openDb(databaseUrl) : null;
+  let probed = 0;
+  let reachable = 0;
+  let hybrid = 0;
+
+  try {
+    if (client) {
+      await ensureSchema(client);
+      await upsertHosts(client, seeds, optout);
+    }
+    // Canonical ids + opt-out state come from the DB (which may include
+    // website-marked opt-outs); in dry-run we fall back to the seed rank.
+    const hostRows = client
+      ? await fetchHostRows(
+          client,
+          seeds.map((s) => s.domain),
+        )
+      : new Map<string, { id: string; optedOut: boolean; rank: number | null }>();
+
+    let first = true;
+    for (const seed of seeds) {
+      const row = hostRows.get(seed.domain);
+      const optedOut = optout.has(seed.domain) || (row?.optedOut ?? false);
+      if (optedOut) {
+        log(`  skip ${seed.domain} (opted out)`);
+        continue;
+      }
+      // Restraint: a minimum gap between successive hosts. No parallel fan-out.
+      if (!first && minIntervalMs > 0) await delay(minIntervalMs);
+      first = false;
+
+      const m = await measureHost(seed.domain, { timeoutMs });
+      probed += 1;
+      if (m.reachable) {
+        reachable += 1;
+        if (m.kexHybrid) hybrid += 1;
+      }
+      const status = m.reachable
+        ? `${m.tlsVersion ?? "?"} kex=${m.kexGroup ?? "?"} hybrid=${m.kexHybrid} sig=${m.certSigAlg ?? "?"}`
+        : `unreachable (${m.error ?? "unknown"})`;
+      log(`  ${seed.domain}: ${status}`);
+
+      if (client) {
+        const hostId = row?.id ?? seed.domain;
+        await upsertProbe(client, hostId, runMonth, m);
+      }
+    }
+
+    let pctHybridKex = reachable > 0 ? Math.round((hybrid / reachable) * 10000) / 100 : 0;
+    if (client) {
+      const rollup = await computeRollup(client, runMonth);
+      pctHybridKex = rollup.pctHybridKex;
+      log(
+        `observatory: rollup ${rollup.runMonth} hosts=${rollup.hostsProbed} ` +
+          `reachable=${rollup.reachable} hybrid=${rollup.hybrid} pct=${rollup.pctHybridKex}%`,
+      );
+    }
+
+    return {
+      runMonth,
+      totalSeed: seeds.length,
+      optedOut: seeds.filter((s) => optout.has(s.domain) || hostRows.get(s.domain)?.optedOut)
+        .length,
+      probed,
+      reachable,
+      hybrid,
+      pctHybridKex,
+      dryRun,
+    };
+  } finally {
+    if (client) await client.end();
+  }
+}

--- a/packages/observatory/tsconfig.json
+++ b/packages/observatory/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // Standalone typecheck config. The observatory is a PRIVATE worker, not a
+  // published package, so it is intentionally NOT listed in the root
+  // tsconfig.json project references and `tsc -b` never builds it. We turn OFF
+  // composite/declaration/emit here (noEmit) so we may import qProbe's internal
+  // source modules directly by relative path (they live outside this package's
+  // src, which composite `rootDir` emit would reject). Run with:
+  //   npx tsc -p packages/observatory/tsconfig.json
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "inlineSources": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds `packages/observatory` (private, unpublished) — the monthly probe worker behind the site's public `/observatory` page.

### What it does
Probes a fixed panel of public hosts (`hosts.txt`, ~67 domains) once a month for PQC-hybrid key exchange (X25519MLKEM768) and certificate posture, writing idempotent per-month results + a rollup to Postgres.

### Design
- Reuses qProbe's **un-gated** TLS primitives (`probeHybridSupport`, `extractNegotiated`) by internal source import. It deliberately does **not** use `runProbe`, which is ownership-gated (`authorizeTargets`) and would refuse hosts we don't own.
- **Restrained policy enforced in code** (not just documented): sequential, min interval between hosts, hard per-connection timeout, no retries, read-only handshakes, opt-out honored before any connection. See `docs/adr/0007`.
- Published packages untouched: **qProbe unchanged**, zero-runtime-dependency and offline-boundary invariants still hold. `pg` is a devDependency of the observatory package only.

### CLI
`npm run observatory -- run --month 2026-07` (flags: `--hosts`, `--optout`, `--timeout`, `--interval`, `--dry-run`). Month = `--month` > `OBS_MONTH` > current UTC month, resolved inside `run()` (no `Date` at module top level).

### Verification
- `tsc -p packages/observatory/tsconfig.json` clean.
- `check-zero-deps` and `check-offline-boundary` pass; root build ignores observatory.
- Live dry-run: Cloudflare/Google `hybrid=true`, GitHub `hybrid=false`; cert fields captured.

### Needs a human (ops)
- A monthly systemd timer / cron on `dl-latest` running the CLI (no separate VM, per ADR).
- `DATABASE_URL` in the worker's env (the website migration owns the tables; the worker `CREATE TABLE IF NOT EXISTS`es them defensively).
- A pass over the `hosts.txt` seed list before the first real run.

Also includes a small doc commit preserving `docs/openssf-best-practices.md` (was a local-only file, kept so nothing is lost).

> One honest note: hybrid vs negotiated KEX are two short handshakes per host (a full handshake plus a raw ClientHello), which is how qProbe defines a probe; documented in the ADR.