### PR TITLE
docs: fix unfinished 'See and' phrase in ADR 0005

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,151 +14,151 @@ Public entry: `packages/core/src/index.ts` — 145 exported symbols.
 
 | Symbol | Kind | Summary |
 | --- | --- | --- |
-| `ANALYZABLE_LANGUAGES_LABEL` | value |  |
-| `ANALYZABLE_SOURCE_EXTENSIONS` | value |  |
-| `AbortError` | value |  |
-| `AlgorithmFamily` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `BASELINE_VERSION` | value |  |
-| `Baseline` | type |  |
-| `BudgetExceededError` | value |  |
-| `CONFIG_FILENAME` | value |  |
-| `CWE_BROKEN_CRYPTO` | value |  |
-| `CWE_CERT_VALIDATION` | value |  |
-| `CWE_HARDCODED_KEY` | value |  |
-| `CWE_RISKY_PRIMITIVE` | value |  |
-| `CWE_WEAK_STRENGTH` | value |  |
-| `CbomComponent` | type |  |
-| `Codemod` | type |  |
-| `Confidence` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `ConfigError` | value |  |
-| `ContextLevel` | type |  |
-| `CryptoInventory` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `CryptoPolicy` | type |  |
-| `CycloneDxBom` | type |  |
-| `DEFAULT_PROFILE_ID` | value |  |
-| `DEP_VULNERABLE_RULE` | value |  |
-| `DependencyEcosystem` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `Detector` | interface | @quantakrypto/core — shared types (the locked public contract). |
+| `ANALYZABLE_LANGUAGES_LABEL` | const | Human label for the source languages the scanner can analyze for inline |
+| `ANALYZABLE_SOURCE_EXTENSIONS` | const | Extensions the scanner can actually analyze for inline crypto usage today |
+| `AbortError` | class | Thrown when a scan is aborted via `ScanOptions.signal`. `name` is `"AbortError"` |
+| `AlgorithmFamily` | type | Classical asymmetric algorithm families that are not quantum-safe. |
+| `BASELINE_VERSION` | const | Current on-disk baseline schema version. |
+| `Baseline` | interface | The on-disk baseline shape: a version tag and a set of fingerprints. |
+| `BudgetExceededError` | class | Thrown when a scan exceeds its `maxFiles` / `maxBytes` work budget mid-walk. |
+| `CONFIG_FILENAME` | const | Canonical config file name discovered at a scan root. |
+| `CWE_BROKEN_CRYPTO` | const | CWE-327: Use of a Broken or Risky Cryptographic Algorithm. |
+| `CWE_CERT_VALIDATION` | const | CWE-295: Improper Certificate Validation. |
+| `CWE_HARDCODED_KEY` | const | CWE-798: Use of Hard-coded Credentials (embedded private keys). |
+| `CWE_RISKY_PRIMITIVE` | const | CWE-1240: Use of a Cryptographic Primitive with a Risky Implementation. |
+| `CWE_WEAK_STRENGTH` | const | CWE-326: Inadequate Encryption Strength. |
+| `CbomComponent` | interface | A single CycloneDX `cryptographic-asset` component. |
+| `Codemod` | interface | A deterministic fix for a class of findings. |
+| `Confidence` | type | How sure the detector is that the finding is a real use of the algorithm. |
+| `ConfigError` | class | Thrown when a known key has a malformed *value* (a usage error: exit 2). |
+| `ContextLevel` | type | How much source context a redacted request carries. |
+| `CryptoInventory` | interface | Aggregated counts produced from a scan's findings. |
+| `CryptoPolicy` | interface | An organization-supplied cryptography policy (from a JSON file). |
+| `CycloneDxBom` | interface | A CycloneDX 1.6 cryptographic bill of materials (kept permissive). |
+| `DEFAULT_PROFILE_ID` | const | The default profile id when `--profile` is not given. |
+| `DEP_VULNERABLE_RULE` | const | Catalog entry for the `dep-vulnerable` rule. Dependency findings are produced |
+| `DependencyEcosystem` | type | Package ecosystems the dependency scanner understands. |
+| `Detector` | interface | A pluggable source detector. Detectors are pure and stateless. |
 | `DetectorInput` | interface |  |
-| `DetectorLanguage` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `DetectorRegistry` | value |  |
-| `DetectorScope` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `EvidenceFinding` | type |  |
-| `EvidenceSigner` | type |  |
-| `FIX_REQUEST_SCHEMA` | value |  |
-| `Finding` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `FindingCategory` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `FixProposal` | type |  |
-| `HybridStance` | type |  |
-| `LoadConfigResult` | type |  |
-| `OpenVexDocument` | type |  |
-| `OpenVexOptions` | type |  |
-| `OpenVexStatement` | type |  |
-| `PQC_STANDARDS` | value |  |
-| `PQC_TRANSITION_NOTE` | value |  |
-| `ParallelScanOptions` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `Patch` | type |  |
-| `PolicyContext` | type |  |
-| `PolicyDecision` | type |  |
-| `PolicyFindingVerdict` | type |  |
-| `PolicyMapping` | type |  |
-| `PolicyVerdict` | type |  |
-| `PqcStandards` | type |  |
-| `QuantakryptoFileConfig` | type |  |
-| `REMEDIATE_RUBRIC` | value |  |
-| `ReadinessReport` | type |  |
-| `ReadinessReportOptions` | type |  |
-| `RedactedContext` | type |  |
-| `RejectedPatch` | type |  |
-| `RemediateOptions` | type |  |
-| `RemediateRequest` | type |  |
-| `Remediation` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `RemediationResult` | type |  |
-| `ReportFormat` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `ReportOptions` | type |  |
-| `RuleMeta` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `SEVERITY_ORDER` | value |  |
-| `STANDARDS_PROFILES` | value |  |
-| `STATEFUL_HBS_NOTE` | value |  |
-| `SarifLog` | type |  |
-| `ScanChunk` | type |  |
-| `ScanDiagnostics` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `ScanOptions` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `ScanResult` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `SecurityTier` | type |  |
-| `Severity` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `SignEvidenceOptions` | type |  |
-| `SourceLocation` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `StandardsCitation` | type |  |
-| `StandardsProfile` | type |  |
-| `StandardsReviewStatus` | type |  |
-| `TIER_PARAMS` | value |  |
-| `TRIAGE_RUBRIC` | value |  |
-| `TRIAGE_VERDICT_SCHEMA` | value |  |
-| `TriageAnnotation` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `TriagePriority` | type | @quantakrypto/core — shared types (the locked public contract). |
-| `TriageRequest` | type |  |
-| `TriageVerdict` | type |  |
-| `VERSION` | value |  |
-| `VerifiedPatch` | type |  |
-| `VerifyReadinessResult` | type |  |
-| `VerifyResult` | type |  |
-| `VulnerableDependency` | interface | @quantakrypto/core — shared types (the locked public contract). |
-| `applyBaseline` | value |  |
-| `baselineFromFindings` | value |  |
-| `buildContext` | value |  |
-| `buildInventory` | value |  |
-| `buildPolicyMapping` | value |  |
-| `buildReadinessReport` | value |  |
-| `buildRemediateRequest` | value |  |
-| `buildTriageRequest` | value |  |
-| `changedFiles` | value |  |
-| `checkPatchPolicy` | value |  |
-| `codemodFor` | value |  |
-| `codemodRegistry` | value |  |
-| `compareFindings` | value |  |
-| `configToggleCodemod` | value |  |
-| `defaultRegistry` | value |  |
-| `defaultStandardsProfile` | value |  |
-| `detectFile` | value |  |
-| `detectors` | value |  |
-| `fingerprintFinding` | value |  |
-| `formatProfileGuidance` | value |  |
-| `formatSummary` | value |  |
-| `formatTierGuidance` | value |  |
-| `getStandardsProfile` | value |  |
-| `isAnalyzableSource` | value |  |
-| `isBinaryPath` | value |  |
-| `isManifestFile` | value |  |
-| `languageToExtension` | value |  |
-| `loadBaseline` | value |  |
-| `loadConfig` | value |  |
-| `looksMinified` | value |  |
-| `meetsThreshold` | value |  |
-| `mergeCboms` | value |  |
-| `parseCryptoPolicy` | value |  |
-| `remediateFindings` | value |  |
-| `remediationFor` | value |  |
-| `remediationForProfile` | value |  |
-| `remediationForTier` | value |  |
-| `renderPreflight` | value |  |
-| `sarifLevel` | value |  |
-| `saveBaseline` | value |  |
-| `scan` | value |  |
-| `scanParallel` | value |  |
-| `severityRank` | value |  |
-| `signReadinessReport` | value |  |
-| `standardsProfileIds` | value |  |
-| `statefulHbsApplies` | value |  |
-| `toCbom` | value |  |
-| `toJson` | value |  |
-| `toOpenVex` | value |  |
-| `toSarif` | value |  |
-| `verifyFix` | value |  |
-| `verifyReadinessReport` | value |  |
-| `vulnerableDependencies` | value |  |
+| `DetectorLanguage` | type | The programming language / surface a detector targets. `"any"` means the |
+| `DetectorRegistry` | class | An ordered, id-indexed collection of detectors. Registration order is |
+| `DetectorScope` | type | Which logical scope a detector belongs to. Drives the source/config scope |
+| `EvidenceFinding` | interface | Stable per-finding record for the evidence body (deterministic per commit). |
+| `EvidenceSigner` | interface | An EXTERNAL signer/timestamper the tool orchestrates. Per ADR-0004 the tool |
+| `FIX_REQUEST_SCHEMA` | const | JSON Schema every fix proposal must satisfy. |
+| `Finding` | interface | A single detected concern. |
+| `FindingCategory` | type | What kind of cryptographic concern a finding represents. |
+| `FixProposal` | interface | An LLM-proposed fix before it enters the deterministic pipeline. |
+| `HybridStance` | type | Whether classical+PQC hybridization is required during the transition, per regime. |
+| `LoadConfigResult` | interface | Result of {@link loadConfig}: the resolved config plus where it came from. |
+| `OpenVexDocument` | interface | An OpenVEX 0.2.0 document. |
+| `OpenVexOptions` | interface | Options for {@link toOpenVex}. |
+| `OpenVexStatement` | interface | A single OpenVEX statement: one synthetic vulnerability over its affected products. |
+| `PQC_STANDARDS` | const | The current snapshot. Update on each quarterly review; the drift test keeps the |
+| `PQC_TRANSITION_NOTE` | const | Forward-looking PQC standards worth tracking beyond the current FIPS 203/204/205 |
+| `ParallelScanOptions` | interface | Extra options for {@link scanParallel}, layered onto {@link ScanOptions}. |
+| `Patch` | interface | A concrete proposed edit: the full new content for a single file. |
+| `PolicyContext` | interface | Files a remediation may write to. |
+| `PolicyDecision` | interface |  |
+| `PolicyFindingVerdict` | interface | One finding's verdict against the policy. |
+| `PolicyMapping` | interface | The `policyMapping` block added to the evidence report. |
+| `PolicyVerdict` | type | The three verdicts a finding can carry against a policy. |
+| `PqcStandards` | interface | The full post-quantum standards snapshot the tool tracks. |
+| `QuantakryptoFileConfig` | interface | The slice of options a `quantakrypto.config.json` can set. A subset of |
+| `REMEDIATE_RUBRIC` | const | The system rubric for a fix proposal. |
+| `ReadinessReport` | interface |  |
+| `ReadinessReportOptions` | interface |  |
+| `RedactedContext` | interface | A finding's context, redacted to a {@link ContextLevel} and secret-stripped. |
+| `RejectedPatch` | interface |  |
+| `RemediateOptions` | interface |  |
+| `RemediateRequest` | interface | A remediation request bundle for the host agent. |
+| `Remediation` | interface | A remediation recommendation for a classical algorithm. |
+| `RemediationResult` | interface |  |
+| `ReportFormat` | type | Output formats qScan / reporters can emit. |
+| `ReportOptions` | interface | Options shared by the structured reporters ({@link toSarif} / {@link toJson}). |
+| `RuleMeta` | interface | Declarative metadata for a single rule a detector can emit. This is the |
+| `SEVERITY_ORDER` | const | Severity ordering, most → least severe. Index 0 is the most severe. |
+| `STANDARDS_PROFILES` | const | Built-in regime profiles. Facts reflect each authority's published PQC-transition |
+| `STATEFUL_HBS_NOTE` | const | Guidance for stateful hash-based signatures (SP 800-208: LMS / XMSS / HSS). |
+| `SarifLog` | interface | Minimal SARIF 2.1.0 log shape (kept permissive on purpose). |
+| `ScanChunk` | interface | One unit of work dispatched to a worker. |
+| `ScanDiagnostics` | interface | Non-fatal things that happened during a scan that reduce coverage. Surfaced so |
+| `ScanOptions` | interface | Options controlling a scan. |
+| `ScanResult` | interface | The full result of a scan. |
+| `SecurityTier` | type | Security tier for remediation guidance. |
+| `Severity` | type | How serious a finding is, ordered most → least severe. |
+| `SignEvidenceOptions` | interface | Options for {@link signReadinessReport}: a detached-signature and/or a timestamp signer. |
+| `SourceLocation` | interface | A precise location inside a scanned file. |
+| `StandardsCitation` | interface | A single standards fact with its citation and when it was last verified. |
+| `StandardsProfile` | interface | A regime's PQC guidance profile. |
+| `StandardsReviewStatus` | interface | Result of {@link standardsReviewStatus}. |
+| `TIER_PARAMS` | const | Per-tier KEM / signature parameter sets. |
+| `TRIAGE_RUBRIC` | const | The system rubric that defines what an exposure verdict means. |
+| `TRIAGE_VERDICT_SCHEMA` | const | JSON Schema every triage verdict must satisfy. |
+| `TriageAnnotation` | interface | Optional LLM triage annotation attached to a finding by `qscan --triage`. |
+| `TriagePriority` | type | Relative urgency an LLM triage pass assigns to a finding. |
+| `TriageRequest` | interface | A triage request bundle: the rubric, the verdict schema, and redacted contexts. |
+| `TriageVerdict` | interface | An LLM triage verdict for a single finding (never suppresses it). The |
+| `VERSION` | const | The tool version surfaced in reports. Kept in its own module so reporters and |
+| `VerifiedPatch` | interface |  |
+| `VerifyReadinessResult` | interface | The result of {@link verifyReadinessReport}. |
+| `VerifyResult` | interface | Result of {@link verifyFix}: the findings that remain, and whether the |
+| `VulnerableDependency` | interface | A known quantum-vulnerable dependency entry. |
+| `applyBaseline` | function | Split findings into those NOT in the baseline (`newFindings`) and those that |
+| `baselineFromFindings` | function | Build a {@link Baseline} from a set of findings (deduped, sorted). |
+| `buildContext` | function | Build the redacted context for `finding` at `level`. `fileContent` is the full |
+| `buildInventory` | function | Build the full inventory (counts + HNDL + score) from a set of findings. |
+| `buildPolicyMapping` | function | Map every finding to a policy verdict, with per-verdict counts. Deterministic: |
+| `buildReadinessReport` | function | Build the A.8.24 readiness report for a scan result. The attestation's |
+| `buildRemediateRequest` | function | Build a remediation request bundle (offline; metadata level unless `readContent`). |
+| `buildTriageRequest` | function | Build a triage request bundle for a set of findings. Offline: for non-metadata |
+| `changedFiles` | function | Return the list of changed files (relative POSIX paths) under `root`. |
+| `checkPatchPolicy` | function | Decide whether `patch` may be applied under `ctx`. |
+| `codemodFor` | function | The first codemod that applies to `finding`, or undefined. |
+| `codemodRegistry` | const | All registered codemods, in priority order. |
+| `compareFindings` | function | Stable comparator: by file, then line, then ruleId. Exported for reuse. |
+| `configToggleCodemod` | const |  |
+| `defaultRegistry` | const | The default registry, preloaded with {@link builtinDetectors}. Used by |
+| `defaultStandardsProfile` | function | The default profile (NIST). Always defined. |
+| `detectFile` | function | Run all applicable detectors + the manifest scanner over a single file's |
+| `detectors` | const | The full set of built-in detectors exposed on the public API. Re-exported |
+| `fingerprintFinding` | function | Stable, line-INSENSITIVE fingerprint of a finding: the hex SHA-256 of |
+| `formatProfileGuidance` | function | Per-family migration targets tailored to a selected {@link StandardsProfile} |
+| `formatSummary` | function | Render a human-readable summary of a scan result. Colour is off by default; |
+| `formatTierGuidance` | function | Per-family migration targets for a CNSA security tier — surfaces the otherwise |
+| `getStandardsProfile` | function | Look up a built-in profile by id, or `undefined` when unknown. |
+| `isAnalyzableSource` | function | True when a path is in a source language the scanner can analyze for crypto. |
+| `isBinaryPath` | function | True if the file's extension marks it as binary / non-text. |
+| `isManifestFile` | function | True if a file path looks like a manifest we can parse for dependencies. |
+| `languageToExtension` | function | Map a language name (or a bare extension) to a source extension whose |
+| `loadBaseline` | function | Load a baseline from disk. Returns an empty baseline (rather than throwing) |
+| `loadConfig` | function | Load a `quantakrypto.config.json` for a scan. |
+| `looksMinified` | function | Heuristic content check for machine-minified / generated files with no |
+| `meetsThreshold` | function | True when `severity` is at or above `threshold` (i.e. at least as severe). |
+| `mergeCboms` | function | Merge CBOMs into one. Components with the same `bom-ref` (same algorithm + |
+| `parseCryptoPolicy` | function | Validate + normalize a parsed policy object (from an operator's JSON file). |
+| `remediateFindings` | function | Run each finding through patchSource → policy → verify, collecting the patches |
+| `remediationFor` | function | Look up the recommended post-quantum remediation for a classical algorithm. |
+| `remediationForProfile` | function | Regime-aware remediation. Composes the base family guidance with a |
+| `remediationForTier` | function | Tier-aware remediation. Returns the base family remediation plus the |
+| `renderPreflight` | function | Render the exact payload text a `--dry-run` preflight would send. |
+| `sarifLevel` | function | Map our severity to a SARIF 2.1.0 result level. |
+| `saveBaseline` | function | Write a baseline derived from the given findings to disk as pretty JSON |
+| `scan` | function | Recursively scan a directory (or single file, or explicit file list) for |
+| `scanParallel` | function | Scan in parallel across a worker-thread pool, falling back to the in-process |
+| `severityRank` | function | Rank of a severity within {@link SEVERITY_ORDER} (0 = most severe). Lower |
+| `signReadinessReport` | function | Fill a readiness report's attestation with a detached signature and/or RFC-3161 |
+| `standardsProfileIds` | function | All built-in profile ids, in a stable order (default first). |
+| `statefulHbsApplies` | function | True when stateful HBS (SP 800-208) is a reasonable alternative for a family. |
+| `toCbom` | function | Build a CycloneDX 1.6 CBOM from a scan result. One component per distinct |
+| `toJson` | function | Serialize a scan result as a plain JSON-friendly object. |
+| `toOpenVex` | function | Build an OpenVEX 0.2.0 document from a scan result. One statement per distinct |
+| `toSarif` | function | Serialize a scan result as SARIF 2.1.0. |
+| `verifyFix` | function | Run all detectors over `code`, selecting them by `filename` (extension) or |
+| `verifyReadinessReport` | function | Recompute the deterministic content hash over a readiness report's body and |
+| `vulnerableDependencies` | const | Known quantum-vulnerable npm dependencies. |
 | `walkFiles` | value |  |
-| `withWorktree` | value |  |
+| `withWorktree` | function | Create a detached worktree of `repoRoot` at HEAD, run `fn` with its path, and |
 
 ## @quantakrypto/qscan
 
@@ -166,61 +166,61 @@ Public entry: `packages/qscan/src/index.ts` — 55 exported symbols.
 
 | Symbol | Kind | Summary |
 | --- | --- | --- |
-| `ArgError` | value |  |
+| `ArgError` | class | Thrown on malformed input; the CLI maps this to exit code 2. |
 | `BASELINE_VERSION` | value |  |
 | `Baseline` | type |  |
-| `ChangedFilesFn` | type | @quantakrypto/qscan — programmatic API. |
-| `ConfigurableKey` | type |  |
-| `EXIT` | const | @quantakrypto/qscan — programmatic API. |
+| `ChangedFilesFn` | type | Resolve the changed-file list for incremental scans. Injectable for testing; |
+| `ConfigurableKey` | type | Option keys that a `quantakrypto.config.json` may also set. When such a key was set |
+| `EXIT` | const | Process-style exit codes qScan uses. |
 | `Finding` | type |  |
-| `HELP_TEXT` | value |  |
-| `ParsedArgs` | type |  |
-| `ParsedRun` | type |  |
-| `QscanFormat` | type |  |
-| `QscanOptions` | type |  |
-| `QscanRun` | interface | @quantakrypto/qscan — programmatic API. |
-| `REMEDIATE_EXIT` | value |  |
-| `REMEDIATE_HELP` | value |  |
-| `RemediateHooks` | type |  |
+| `HELP_TEXT` | const | The full `--help` screen. |
+| `ParsedArgs` | type | Result of {@link parseArgs}: either resolved options or a meta action. |
+| `ParsedRun` | interface | A successful parse: resolved options plus which configurable keys were explicit. |
+| `QscanFormat` | type | Output formats qScan accepts on the command line. Extends core's |
+| `QscanOptions` | interface | Fully-resolved options the CLI/programmatic runner operates on. |
+| `QscanRun` | interface | Outcome of {@link runQscan}. |
+| `REMEDIATE_EXIT` | const |  |
+| `REMEDIATE_HELP` | const |  |
+| `RemediateHooks` | interface |  |
 | `RemediateMode` | type |  |
-| `RemediateOptions` | type |  |
-| `RemediateRun` | type |  |
-| `RenderReportOptions` | interface | @quantakrypto/qscan — programmatic API. |
-| `ResolvedConfig` | type |  |
-| `RunQscanHooks` | interface | @quantakrypto/qscan — programmatic API. |
+| `RemediateOptions` | interface |  |
+| `RemediateRun` | interface |  |
+| `RenderReportOptions` | interface | Rendering controls for {@link renderReport}. |
+| `ResolvedConfig` | interface | What {@link resolveConfig} returns: the merged options + provenance. |
+| `RunQscanHooks` | interface | Behavioral hooks for {@link runQscan}, mainly for testing. |
 | `SEVERITY_ORDER` | value |  |
-| `ScanFn` | type | @quantakrypto/qscan — programmatic API. |
+| `ScanFn` | type | The scan implementation `runQscan` calls. Matches `@quantakrypto/core`'s `scan` / |
 | `ScanOptions` | type |  |
 | `ScanResult` | type |  |
-| `applyBaseline` | value |  |
-| `applyConfig` | value |  |
-| `asFormat` | value |  |
-| `asInt` | value |  |
-| `asSeverity` | value |  |
+| `applyBaseline` | function | Partition findings into those kept and those suppressed by a baseline. |
+| `applyConfig` | function | Apply a parsed config onto options under the precedence rule. Pure; returns a |
+| `asFormat` | function | Validate/normalize a `--format` value. |
+| `asInt` | function | Validate/normalize a non-negative integer flag value. |
+| `asSeverity` | function | Validate/normalize a severity value. |
 | `baselineFromFindings` | value |  |
-| `buildBaseline` | value |  |
-| `defaultOptions` | value |  |
-| `fingerprint` | value |  |
+| `buildBaseline` | function | Build a {@link Baseline} from a set of findings (deduped + sorted). Alias for |
+| `defaultOptions` | function | Default options, before any flags are applied. |
+| `fingerprint` | const | Compute a stable fingerprint for a finding. Alias for core's |
 | `fingerprintFinding` | value |  |
 | `loadBaseline` | value |  |
 | `meetsThreshold` | value |  |
-| `parseArgs` | value |  |
-| `parseRemediateArgs` | value |  |
-| `readBaseline` | value |  |
-| `renderCbom` | value |  |
-| `renderHuman` | value |  |
-| `renderJson` | value |  |
-| `renderReport` | function | @quantakrypto/qscan — programmatic API. |
-| `renderSarif` | value |  |
-| `renderVex` | value |  |
-| `resolveConfig` | value |  |
-| `runQscan` | function | @quantakrypto/qscan — programmatic API. |
-| `runRemediate` | value |  |
+| `parseArgs` | function |  |
+| `parseRemediateArgs` | function | Parse qremediate argv. |
+| `readBaseline` | function | Read a baseline file from disk and return its accepted fingerprints as a set. |
+| `renderCbom` | function | Render a CycloneDX 1.6 CBOM (cryptographic bill of materials) for the scan, |
+| `renderHuman` | function | Render the human-readable banner. |
+| `renderJson` | function | Render the JSON report (pretty-printed, no trailing newline). |
+| `renderReport` | function | Render a scan result in the requested format. |
+| `renderSarif` | function | Render the SARIF 2.1.0 report (pretty-printed, no trailing newline). |
+| `renderVex` | function | Render an OpenVEX 0.2.0 document for the scan (pretty-printed, no trailing |
+| `resolveConfig` | function | Load and merge `quantakrypto.config.json` into the parsed CLI options. |
+| `runQscan` | function | Run a complete qScan pass: scan → baseline → threshold → render. |
+| `runRemediate` | function | Run a complete qremediate pass. Pure w.r.t. process; the bin prints + exits. |
 | `saveBaseline` | value |  |
 | `severityRank` | value |  |
-| `unifiedDiff` | value |  |
-| `versionLine` | value |  |
-| `writeBaseline` | value |  |
+| `unifiedDiff` | function | Minimal unified diff for a localized change (3 lines of context). |
+| `versionLine` | function | The `--version` line. |
+| `writeBaseline` | function | Serialize and write a baseline to disk (pretty-printed, trailing newline). |
 
 ## @quantakrypto/mcp
 
@@ -228,31 +228,31 @@ Public entry: `packages/mcp/src/index.ts` — 25 exported symbols.
 
 | Symbol | Kind | Summary |
 | --- | --- | --- |
-| `CORE_VERSION` | value |  |
+| `CORE_VERSION` | const | The core version these tools are built against (re-exported for diagnostics). |
 | `Content` | type |  |
 | `CreateServerOptions` | interface |  |
-| `ErrorCode` | value |  |
-| `JSONRPC_VERSION` | value |  |
-| `JsonRpcFailure` | type |  |
-| `JsonRpcRequest` | type |  |
+| `ErrorCode` | const | Standard JSON-RPC 2.0 error codes (plus MCP conventions). |
+| `JSONRPC_VERSION` | const | The fixed JSON-RPC protocol marker. |
+| `JsonRpcFailure` | interface | A failed JSON-RPC response. |
+| `JsonRpcRequest` | interface | A JSON-RPC 2.0 request or notification (notifications omit `id`). |
 | `JsonRpcResponse` | type |  |
-| `JsonRpcSuccess` | type |  |
-| `JsonSchema` | type |  |
-| `MCP_PROTOCOL_VERSION` | value |  |
-| `McpServer` | value |  |
-| `McpServerOptions` | type |  |
-| `RpcError` | value |  |
-| `SERVER_NAME` | const | @quantakrypto/mcp — public API. |
-| `SERVER_VERSION` | const | @quantakrypto/mcp — public API. |
-| `ServerInfo` | type |  |
-| `TextContent` | type |  |
-| `ToolDefinition` | type |  |
-| `ToolDescriptor` | type |  |
-| `ToolResult` | type |  |
-| `createQuantakryptoServer` | function | @quantakrypto/mcp — public API. |
-| `errorResult` | value |  |
-| `quantakryptoTools` | value |  |
-| `textResult` | value |  |
+| `JsonRpcSuccess` | interface | A successful JSON-RPC response. |
+| `JsonSchema` | interface | A minimal JSON Schema object describing a tool's input. |
+| `MCP_PROTOCOL_VERSION` | const | MCP protocol revision this server speaks. The `initialize` handshake echoes |
+| `McpServer` | class | A minimal, spec-faithful MCP server. Register tools with {@link registerTool} |
+| `McpServerOptions` | interface |  |
+| `RpcError` | class | An error that carries a JSON-RPC error code, thrown by tool handlers/dispatch. |
+| `SERVER_NAME` | const | The MCP server name advertised to clients. |
+| `SERVER_VERSION` | const | The version reported by the server (kept in sync with @quantakrypto/core). |
+| `ServerInfo` | interface | Identifying info advertised to clients during `initialize`. |
+| `TextContent` | interface | A single piece of MCP content. We only emit text content in this server. |
+| `ToolDefinition` | interface | A registered tool: descriptor plus its async handler. |
+| `ToolDescriptor` | interface | The public descriptor of a tool, as returned by `tools/list`. |
+| `ToolResult` | interface | The result envelope returned by a `tools/call`. |
+| `createQuantakryptoServer` | function | Create a fully-wired quantakrypto {@link McpServer} with all tools registered. |
+| `errorResult` | function | Convenience: wrap a string as an error text tool result. |
+| `quantakryptoTools` | const | All quantakrypto MCP tools, in a stable order. |
+| `textResult` | function | Convenience: wrap one or more strings as a non-error text tool result. |
 
 ## @quantakrypto/sieve
 
@@ -260,52 +260,52 @@ Public entry: `packages/sieve/src/index.ts` — 46 exported symbols.
 
 | Symbol | Kind | Summary |
 | --- | --- | --- |
-| `BugClass` | type |  |
-| `CATEGORIES` | value |  |
-| `CategoryCounts` | type |  |
-| `CategoryResult` | type |  |
-| `Check` | type |  |
-| `DEFAULT_ENV_ALLOWLIST` | value |  |
-| `DsaSizes` | type |  |
-| `Family` | type |  |
-| `KemSizes` | type |  |
-| `PARAM_SETS` | value |  |
-| `PROTOCOL_VERSION` | value |  |
-| `ParamSet` | type |  |
-| `ProtocolError` | value |  |
-| `Request` | type |  |
-| `Response` | type |  |
-| `RunSieveOptions` | interface | @quantakrypto/sieve — programmatic API. |
-| `Runner` | value |  |
-| `RunnerOptions` | type |  |
-| `SieveReport` | type |  |
-| `SignatureFamily` | type |  |
-| `SignatureSizes` | type |  |
-| `Sizes` | type |  |
-| `SlhDsaSizes` | type |  |
-| `Status` | type |  |
-| `SutCrashError` | value |  |
-| `TimeoutError` | value |  |
-| `Vector` | type |  |
-| `VectorSet` | type |  |
-| `asDsaSizes` | value |  |
-| `asKemSizes` | value |  |
-| `asSignatureSizes` | value |  |
-| `asSlhDsaSizes` | value |  |
-| `buildReport` | value |  |
-| `buildSutEnv` | value |  |
-| `categoriesFor` | value |  |
-| `decodeResponse` | value |  |
-| `encodeRequest` | value |  |
-| `formatHuman` | value |  |
-| `formatJson` | value |  |
-| `fromB64` | value |  |
-| `isParamSet` | value |  |
-| `loadVectors` | value |  |
-| `overallVerdict` | value |  |
-| `runSieve` | function | @quantakrypto/sieve — programmatic API. |
-| `sizesFor` | value |  |
-| `toB64` | value |  |
+| `BugClass` | type | A bug-class tag linking a category/check to quantakrypto's antiform taxonomy. |
+| `CATEGORIES` | const | The full catalog, in execution order. |
+| `CategoryCounts` | interface | Per-category counts. |
+| `CategoryResult` | interface | The aggregate outcome of running one category. |
+| `Check` | interface | One atomic assertion within a category. |
+| `DEFAULT_ENV_ALLOWLIST` | const | Minimal environment variables a child process generally needs to locate its |
+| `DsaSizes` | interface | Byte sizes for an ML-DSA parameter set (FIPS 204, Table 2). |
+| `Family` | type | Algorithm families Sieve knows how to drive. |
+| `KemSizes` | interface | Byte sizes for an ML-KEM parameter set (FIPS 203, Table 3). |
+| `PARAM_SETS` | const | All known parameter-set identifiers, in canonical order. |
+| `PROTOCOL_VERSION` | const | Protocol version. Bumped on any breaking wire change. |
+| `ParamSet` | type | Canonical parameter-set identifiers accepted on the CLI / API. |
+| `ProtocolError` | class | Raised when a line from the SUT cannot be parsed into a valid Response. |
+| `Request` | type | Any request Sieve may send. |
+| `Response` | type | Any response the SUT may emit. |
+| `RunSieveOptions` | interface | Options for {@link runSieve}. |
+| `Runner` | class | A long-lived handle to a spawned SUT. Construct once per test run, issue many |
+| `RunnerOptions` | interface | Options for constructing a {@link Runner}. |
+| `SieveReport` | interface | The full report. |
+| `SignatureFamily` | type | Families that support the signature operations (sign / verify). |
+| `SignatureSizes` | type | A signature-family size record (ML-DSA or SLH-DSA). |
+| `Sizes` | type | Union of the size shapes. |
+| `SlhDsaSizes` | interface | Byte sizes for an SLH-DSA parameter set (FIPS 205, Table 2). |
+| `Status` | type | Status of a single check or a whole category. |
+| `SutCrashError` | class | Thrown when the SUT process dies before/while a request is in flight. |
+| `TimeoutError` | class | Thrown when a request exceeds its timeout. |
+| `Vector` | type | Any normalized vector. |
+| `VectorSet` | interface | Result of scanning a vectors directory. |
+| `asDsaSizes` | function | Narrowing helper: DSA size record or `undefined`. |
+| `asKemSizes` | function | Narrowing helper: KEM size record or `undefined`. |
+| `asSignatureSizes` | function | Narrowing helper: any signature-family size record (ML-DSA or SLH-DSA) or |
+| `asSlhDsaSizes` | function | Narrowing helper: SLH-DSA size record or `undefined`. |
+| `buildReport` | function | Assemble a {@link SieveReport} from category results and run metadata. |
+| `buildSutEnv` | function | Build the environment handed to the spawned SUT. |
+| `categoriesFor` | function | Categories applicable to a family (plus family-agnostic ones). |
+| `decodeResponse` | function | Parse one NDJSON line from the SUT into a validated {@link Response}. |
+| `encodeRequest` | function | Serialize a request to a single NDJSON line (including the trailing "\n"). |
+| `formatHuman` | function | Human-readable terminal rendering (no color codes; CI-friendly). |
+| `formatJson` | function | Pretty JSON rendering. |
+| `fromB64` | function | Decode a base64 string to bytes. |
+| `isParamSet` | function | Type guard: is `s` a recognized parameter-set identifier? |
+| `loadVectors` | function |  |
+| `overallVerdict` | function | Compute the overall verdict: FAIL if any non-advisory category failed. |
+| `runSieve` | function | Spawn the SUT, run the applicable categories, and return an aggregated |
+| `sizesFor` | function | Look up the size record for a parameter set. |
+| `toB64` | function | Encode raw bytes to a base64 string. |
 
 ## @quantakrypto/agent
 
@@ -314,23 +314,23 @@ Public entry: `packages/agent/src/index.ts` — 18 exported symbols.
 | Symbol | Kind | Summary |
 | --- | --- | --- |
 | `AGENT_PACKAGE` | const | @quantakrypto/agent — BYOK LLM client for qScan triage and remediation. |
-| `FIX_PROMPT_VERSION` | value |  |
-| `JsonSchema` | type |  |
-| `LlmClient` | type |  |
-| `LlmConfig` | type |  |
-| `LlmRequest` | type |  |
-| `ProposeFixOptions` | type |  |
-| `TRIAGE_PROMPT_VERSION` | value |  |
-| `TriageOptions` | type |  |
-| `anthropicClient` | value |  |
-| `cacheKey` | value |  |
-| `loadResponseCache` | value |  |
-| `openAiCompatibleClient` | value |  |
-| `proposeFix` | value |  |
-| `resolveClient` | value |  |
-| `saveResponseCache` | value |  |
-| `triageFindings` | value |  |
-| `validateAgainstSchema` | value |  |
+| `FIX_PROMPT_VERSION` | const | Bump when the fix rubric/schema changes. |
+| `JsonSchema` | type | A tiny JSON-Schema validator covering exactly the subset the agent emits |
+| `LlmClient` | interface | A provider adapter: turns an {@link LlmRequest} into schema-valid JSON. |
+| `LlmConfig` | interface | BYOK provider configuration. `apiKey` is resolved from env by the caller. |
+| `LlmRequest` | interface | A single structured completion request. |
+| `ProposeFixOptions` | interface |  |
+| `TRIAGE_PROMPT_VERSION` | const | Bump when the rubric/schema changes so the response cache invalidates. |
+| `TriageOptions` | interface |  |
+| `anthropicClient` | function |  |
+| `cacheKey` | function | Compose the cache key for one finding's request. |
+| `loadResponseCache` | function | Load the response cache, or an empty map on any problem. |
+| `openAiCompatibleClient` | function |  |
+| `proposeFix` | function | Ask the model for a fix. Returns a {@link FixProposal} (full new file content) |
+| `resolveClient` | function | Pick the adapter for `config.provider`. `fetchImpl` is injectable for tests. |
+| `saveResponseCache` | function | Write the response cache atomically. Errors are swallowed. |
+| `triageFindings` | function | Produce an exposure verdict per above-floor finding. |
+| `validateAgainstSchema` | function | Validate `value` against the JSON-Schema subset we emit. |
 
 ## @quantakrypto/qprobe
 
@@ -338,45 +338,45 @@ Public entry: `packages/qprobe/src/index.ts` — 42 exported symbols.
 
 | Symbol | Kind | Summary |
 | --- | --- | --- |
-| `AttestationError` | value |  |
-| `AttestationInput` | value |  |
+| `AttestationError` | class |  |
+| `AttestationInput` | interface |  |
 | `EndpointReport` | interface |  |
 | `GROUP_SECP256R1` | const |  |
 | `GROUP_X25519` | const |  |
 | `GROUP_X25519MLKEM768` | const |  |
-| `HybridSupport` | type |  |
-| `IMAP_DIALOG` | value |  |
-| `KexInit` | type |  |
-| `POP3_DIALOG` | value |  |
-| `PQ_SSH_KEX` | value |  |
+| `HybridSupport` | interface |  |
+| `IMAP_DIALOG` | const | IMAP (RFC 3501): `* OK` greeting → `a1 STARTTLS` → `a1 OK`. |
+| `KexInit` | interface |  |
+| `POP3_DIALOG` | const | POP3 (RFC 2595): `+OK` greeting → `STLS` → `+OK`. |
+| `PQ_SSH_KEX` | const | PQC / hybrid SSH key-exchange algorithm names (OpenSSH + drafts). |
 | `ProbeMode` | type |  |
 | `RunOptions` | interface |  |
 | `RunResult` | interface |  |
-| `ServerHelloInfo` | interface | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `SshProbeResult` | type |  |
-| `Target` | type |  |
-| `TargetError` | value |  |
-| `TlsNegotiated` | type |  |
-| `TlsRecord` | interface | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `authorizeTargets` | value |  |
-| `buildClientHello` | function | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `certSignatureAlgorithm` | value |  |
-| `classifySsh` | value |  |
-| `classifyTls` | value |  |
-| `decodeOid` | value |  |
-| `oidToSignatureFamily` | value |  |
-| `parseOwnedHosts` | value |  |
-| `parseRecords` | function | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `parseServerHelloBody` | function | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `parseTarget` | value |  |
-| `readServerHello` | function | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
-| `resolveMode` | function | @quantakrypto/qprobe — active post-quantum readiness probing of live TLS/SSH |
-| `runProbe` | function | @quantakrypto/qprobe — active post-quantum readiness probing of live TLS/SSH |
-| `smtpAdvertisesStartTls` | value |  |
-| `smtpReplyComplete` | value |  |
-| `sslRequestFrame` | value |  |
-| `toCbomReport` | value |  |
-| `toJsonReport` | value |  |
-| `toSarifReport` | value |  |
-| `toScanResult` | value |  |
-| `x25519RawPublic` | function | Minimal, hand-rolled TLS 1.3 ClientHello builder + ServerHello/HelloRetryRequest |
+| `ServerHelloInfo` | interface | The result of reading a ServerHello / HelloRetryRequest. |
+| `SshProbeResult` | interface |  |
+| `Target` | interface | A single validated endpoint. |
+| `TargetError` | class |  |
+| `TlsNegotiated` | interface |  |
+| `TlsRecord` | interface | A parsed TLS record. |
+| `authorizeTargets` | function | Authorize a set of targets or throw {@link AttestationError}. Returns silently |
+| `buildClientHello` | function | Build a raw ClientHello TLS record advertising the hybrid group. `keyShareGroup` |
+| `certSignatureAlgorithm` | function | Extract the signatureAlgorithm OID (and mapped family) from a DER certificate. |
+| `classifySsh` | function | Findings for an SSH endpoint from its KEXINIT. |
+| `classifyTls` | function | Findings for a TLS endpoint from the negotiated params + the hybrid probe. |
+| `decodeOid` | function | Decode a DER OID value (the bytes inside the OID TLV) to dotted-decimal. |
+| `oidToSignatureFamily` | function | Map a signature-algorithm OID to a classical family (or undefined). |
+| `parseOwnedHosts` | function | Parse an ownership manifest file's text into a host allow-list. |
+| `parseRecords` | function | Split a buffer into TLS records. Stops at the first truncated record. |
+| `parseServerHelloBody` | function | Parse a ServerHello handshake message body (the bytes AFTER the 4-byte handshake |
+| `parseTarget` | function | Parse and validate a single target. Throws {@link TargetError} for anything |
+| `readServerHello` | function | Read the first ServerHello/HRR out of a raw response buffer, if any. |
+| `resolveMode` | function | Choose a probe mode for "auto" from the well-known port: SSH on 22, SMTP |
+| `runProbe` | function | Authorize (throws {@link AttestationError} / {@link TargetError} on failure — no |
+| `smtpAdvertisesStartTls` | function | True if an EHLO reply advertises the STARTTLS capability. |
+| `smtpReplyComplete` | function | True once `buf` contains a COMPLETE SMTP reply (last line is `NNN␠…`). |
+| `sslRequestFrame` | function | The 8-byte libpq SSLRequest message: length(0x00000008) + code(80877103). |
+| `toCbomReport` | function |  |
+| `toJsonReport` | function |  |
+| `toSarifReport` | function |  |
+| `toScanResult` | function | Adapt a {@link RunResult} to a {@link ScanResult}. `filesScanned` is the number |
+| `x25519RawPublic` | function | A raw 32-byte X25519 public key (from node:crypto — a real, valid key). |

--- a/docs/SUPPLY-CHAIN.md
+++ b/docs/SUPPLY-CHAIN.md
@@ -2,7 +2,7 @@
 
 How `quantakrypto-tools` targets the three pillars of OSS supply-chain assurance —
 **OpenSSF Scorecard**, **SLSA / npm provenance**, and **SPDX/REUSE licensing** —
-and where the project stands against each today. This operationalises and the supply-chain section of [COMPLIANCE.md](COMPLIANCE.md §5).
+and where the project stands against each today. This operationalises the supply-chain section of [COMPLIANCE.md §5](COMPLIANCE.md).
 
 The project's strongest asset here is the [zero-runtime-dependency](adr/0001-zero-runtime-dependencies.md)
 posture: no transitive CVEs, no lifecycle scripts, a tiny dev-tool surface. That

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -14,7 +14,7 @@ All packages follow [Semantic Versioning 2.0.0](https://semver.org): `MAJOR.MINO
 - **PATCH** — backward-compatible bug fixes (including detection-accuracy fixes
   that do not change the data contract).
 
-### Pre-1.0 reality (today: all packages `0.5.0` tagged; `0.4.4` published)
+### Pre-1.0 reality (all packages are in the `0.x` range)
 
 Under SemVer's 0.x rule, **anything may change in a minor release** and the public
 API is explicitly **pre-stable**. We make **no compatibility promises before 1.0**

--- a/docs/adr/0003-monorepo-and-build.md
+++ b/docs/adr/0003-monorepo-and-build.md
@@ -46,7 +46,7 @@ contributors run three commands (`npm install` / `npm run build` / `npm test`).
   **freshness gate** (`action-bundle` in [ci.yml](../../.github/workflows/ci.yml))
   re-bundles and fails the build if the committed `dist/` drifts from source. (One
   release caveat remains — the moving `v1` tag is not yet re-pointed at the current
-  release, so it can lag `main`; see [OBJECTIVES.md](OBJECTIVES.md).) This was a
+  release, so it can lag `main`; see [OBJECTIVES.md](../OBJECTIVES.md).) This was a
   deliberate consequence of choosing a monorepo + a compiled action.
 - **Shared versioning discipline.** Independent publish + a shared contract means
   version bumps must follow [VERSIONING.md](../VERSIONING.md) so a core change and

--- a/docs/adr/0005-byok-agent-two-planes.md
+++ b/docs/adr/0005-byok-agent-two-planes.md
@@ -88,7 +88,7 @@ imported by both planes.
   **"crypto-verified, not security-reviewed"** and must be reviewed as a diff.
   *(F1) **Resolved**: a blast-radius guard now bounds a patch to the finding's file
   set + dependency manifests, and the output framing says "crypto-verified, not
-  security-reviewed" honestly — see [OBJECTIVES.md](OBJECTIVES.md).*
+  security-reviewed" honestly — see [OBJECTIVES.md](../OBJECTIVES.md).*
 - **On the MCP plane the gates are advisory** — the host agent writes files, so
   patch-policy/`verify_fix` are not enforced there. Documented, not code-guaranteed. (F5)
 - *(F2, F3) **Resolved**: instruction/data separation now travels via the provider's

--- a/docs/adr/0005-byok-agent-two-planes.md
+++ b/docs/adr/0005-byok-agent-two-planes.md
@@ -94,7 +94,7 @@ imported by both planes.
 - *(F2, F3) **Resolved**: instruction/data separation now travels via the provider's
   real `system` role (the rubric out-ranks the untrusted user turn, with an explicit
   anti-injection preamble), and a per-run spend ceiling (`--max-findings`) caps LLM
-  calls. See and `packages/agent/src/loop.ts`.*
+  calls. See `packages/agent/src/loop.ts`.*
 
 ## Alternatives considered
 

--- a/scripts/gen-api-reference.mjs
+++ b/scripts/gen-api-reference.mjs
@@ -82,16 +82,25 @@ function exportedName(clause) {
   return asMatch ? asMatch[1] : clause.trim().replace(/^type\s+/, "");
 }
 
-/** Best-effort one-line doc summary for `name` declared in `src` (from its doc block). */
+/**
+ * Best-effort one-line doc summary for `name` declared in `src`: the first line of the
+ * JSDoc block that ends immediately above the declaration (whitespace-only in between).
+ * Anchoring to the declaration first — rather than scanning left-to-right for a
+ * doc-comment-then-export pair — is deliberate: it never mis-attributes a file's module
+ * header (or an earlier symbol's block) to a symbol that has no doc comment of its own.
+ */
 function docFor(src, name) {
-  const pattern =
-    String.raw`\/\*\*([\s\S]*?)\*\/\s*export\s+(?:(?:declare|async|abstract)\s+)*` +
-    String.raw`(?:const|function|class|interface|type|enum)\s+` +
-    name +
-    String.raw`\b`;
-  const m = src.match(new RegExp(pattern));
-  if (!m) return "";
-  const first = m[1]
+  const decl = new RegExp(
+    String.raw`export\s+(?:(?:declare|async|abstract)\s+)*` +
+      String.raw`(?:const|function|class|interface|type|enum)\s+` +
+      name +
+      String.raw`\b`,
+  ).exec(src);
+  if (!decl) return "";
+  // A single JSDoc block (containing no comment terminator) sitting right before the decl.
+  const preceding = src.slice(0, decl.index).match(/\/\*\*((?:(?!\*\/)[\s\S])*)\*\/\s*$/);
+  if (!preceding) return "";
+  const first = preceding[1]
     .split("\n")
     .map((l) => l.replace(/^\s*\*?\s?/, "").trim())
     .find((l) => l.length > 0);
@@ -126,11 +135,32 @@ function collectExports(entryRel) {
   }
 
   // `export { a, b as c } from "…"` and `export type { … } from "…"` (may span lines).
-  for (const m of src.matchAll(/export\s+(type\s+)?\{([\s\S]*?)\}\s*from\s+["'][^"']+["']/g)) {
+  // Resolve the source module so re-exported symbols get their real kind and doc summary
+  // (not a blank), the same way `export * from` above does.
+  for (const m of src.matchAll(/export\s+(type\s+)?\{([\s\S]*?)\}\s*from\s+["']([^"']+)["']/g)) {
     const isType = Boolean(m[1]);
+    let modRaw = "";
+    try {
+      modRaw = readFileSync(resolve(dirname(entryAbs), m[3].replace(/\.js$/, ".ts")), "utf8");
+    } catch {
+      /* re-export from a package or an unresolved path — leave kind/doc best-effort */
+    }
+    const modSrc = modRaw ? stripComments(modRaw) : "";
     for (const clause of m[2].split(",")) {
       const name = exportedName(clause);
-      if (name) out.set(name, { kind: isType ? "type" : "value", doc: "" });
+      if (!name) continue;
+      // The clause's original (pre-`as`) identifier, used to find the declaration.
+      const orig = (clause.trim().match(/^(?:type\s+)?([\w$]+)/) || [])[1] || name;
+      let kind = isType ? "type" : "value";
+      if (modSrc) {
+        const d = new RegExp(
+          String.raw`export\s+(?:(?:declare|async|abstract)\s+)*(const|function|class|interface|type|enum)\s+` +
+            orig +
+            String.raw`\b`,
+        ).exec(modSrc);
+        if (d) kind = d[1] === "function" ? "function" : d[1];
+      }
+      out.set(name, { kind, doc: modRaw ? docFor(modRaw, orig) : "" });
     }
   }
 


### PR DESCRIPTION
One-line follow-up to #34: ADR 0005 read "See and `packages/agent/src/loop.ts`" — dropped the stray "and".

Leaving this for a manual merge per the repo's own **"No auto-merge, ever"** guardrail (ADR 0005). Docs-only.