### PR TITLE
core: stable finding fingerprints in JSON and SARIF output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+### Added: stable finding fingerprints in JSON and SARIF output
+
+- Every finding in the `--report json` output now carries a top-level
+  `fingerprint` field, and each SARIF result mirrors the same value in
+  `properties.fingerprint` (alongside the existing `partialFingerprints`). It is
+  the line-INSENSITIVE identity already used by the baseline: `sha256(ruleId |
+  normalized-POSIX-repo-relative-path | normalized-snippet)`, with the volatile
+  line number deliberately excluded and a rule+path fallback when no snippet
+  context exists. A line move does not change it, so downstream consumers can key
+  finding identity across runs (posture drift, migration tracking) rather than
+  re-reading a shifted finding as new-plus-resolved. Reuses `fingerprintFinding`
+  from the baseline module (no new public API), so JSON identity, SARIF
+  `partialFingerprints`, and the baseline suppression set are one value. Additive
+  and backward compatible.
+
 ### Added — new detection surfaces (Solidity/blockchain, WebAuthn, proxy/gRPC TLS, code-signing, weak-hash)
 
 Five new detectors from a fresh coverage-gap research pass (52 detectors / 297 rules):

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -1413,7 +1413,7 @@ async function* walkFiles(root, options = {}) {
 }
 function passesSizeLimit(rel, size, maxFileSize) {
   if (isManifestFile(rel))
-    return true;
+    return size <= MANIFEST_MAX_BYTES;
   return size <= maxFileSize;
 }
 async function* walkDir(absDir, relDir, ctx) {
@@ -1459,7 +1459,7 @@ async function* walkDir(absDir, relDir, ctx) {
     yield rel;
   }
 }
-var DEFAULT_IGNORES, DEFAULT_MAX_FILE_SIZE, BINARY_EXTENSIONS, GLOB_CACHE, KEYSTORE_EXTENSIONS, GENERATED_PATH_RE;
+var DEFAULT_IGNORES, DEFAULT_MAX_FILE_SIZE, BINARY_EXTENSIONS, GLOB_CACHE, KEYSTORE_EXTENSIONS, GENERATED_PATH_RE, MANIFEST_MAX_BYTES;
 var init_walk = __esm({
   "../core/dist/walk.js"() {
     "use strict";
@@ -1557,6 +1557,7 @@ var init_walk = __esm({
       ".kbx"
     ]);
     GENERATED_PATH_RE = /(?:\.min\.[mc]?js|[.-]min\.[mc]?js|\.bundle\.[mc]?js|\.chunk\.[mc]?js|\.generated\.[jt]sx?|_pb\.js|\.pb\.go)$/i;
+    MANIFEST_MAX_BYTES = 16 * 1024 * 1024;
   }
 });
 
@@ -10177,6 +10178,10 @@ function toSarif(result, opts) {
       // edit above it. `quantakrypto/v1` names our scheme.
       partialFingerprints: { "quantakrypto/v1": fingerprintFinding(f) },
       properties: {
+        // Same stable identity mirrored into properties so non-GitHub SARIF
+        // consumers (our platform ingest) can read one uniform `fingerprint`
+        // field across JSON and SARIF without reaching into partialFingerprints.
+        fingerprint: fingerprintFinding(f),
         category: f.category,
         severity: f.severity,
         confidence: f.confidence,
@@ -10268,6 +10273,15 @@ function toJson(result, opts) {
       byAlgorithm: result.inventory.byAlgorithm
     },
     findings: result.findings.map((f) => ({
+      // Stable, line-INSENSITIVE identity of the finding: sha256 of
+      // ruleId | normalized-POSIX-repo-relative-path | normalized-snippet
+      // (the SARIF partialFingerprints trick, line number deliberately
+      // excluded). Reused verbatim from the baseline module so JSON identity,
+      // SARIF partialFingerprints, and the baseline suppression set are one and
+      // the same value. A line move does NOT change it; when no snippet context
+      // exists it falls back to ruleId|path. This is the cross-run identity the
+      // platform keys posture drift on.
+      fingerprint: fingerprintFinding(f),
       ruleId: f.ruleId,
       title: f.title,
       category: f.category,

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -171,6 +171,10 @@ export function toSarif(result: ScanResult, opts?: ReportOptions): SarifLog {
       // edit above it. `quantakrypto/v1` names our scheme.
       partialFingerprints: { "quantakrypto/v1": fingerprintFinding(f) },
       properties: {
+        // Same stable identity mirrored into properties so non-GitHub SARIF
+        // consumers (our platform ingest) can read one uniform `fingerprint`
+        // field across JSON and SARIF without reaching into partialFingerprints.
+        fingerprint: fingerprintFinding(f),
         category: f.category,
         severity: f.severity,
         confidence: f.confidence,
@@ -274,6 +278,15 @@ export function toJson(result: ScanResult, opts?: ReportOptions): Record<string,
       byAlgorithm: result.inventory.byAlgorithm,
     },
     findings: result.findings.map((f) => ({
+      // Stable, line-INSENSITIVE identity of the finding: sha256 of
+      // ruleId | normalized-POSIX-repo-relative-path | normalized-snippet
+      // (the SARIF partialFingerprints trick, line number deliberately
+      // excluded). Reused verbatim from the baseline module so JSON identity,
+      // SARIF partialFingerprints, and the baseline suppression set are one and
+      // the same value. A line move does NOT change it; when no snippet context
+      // exists it falls back to ruleId|path. This is the cross-run identity the
+      // platform keys posture drift on.
+      fingerprint: fingerprintFinding(f),
       ruleId: f.ruleId,
       title: f.title,
       category: f.category,

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -12,6 +12,7 @@ import {
   remediationFor,
   buildInventory,
   defaultRegistry,
+  fingerprintFinding,
   VERSION,
 } from "../src/index.js";
 import type { AlgorithmFamily, Finding, ScanResult } from "../src/index.js";
@@ -244,6 +245,128 @@ test("toJson returns a clean structured object", () => {
   assert.ok(typeof inv.readinessScore === "number");
   // Round-trips through JSON without throwing.
   assert.doesNotThrow(() => JSON.parse(JSON.stringify(json)));
+});
+
+test("toJson stamps a stable fingerprint on every finding", () => {
+  const json = toJson(sampleResult());
+  const findings = json.findings as Array<Record<string, unknown>>;
+  for (const f of findings) {
+    assert.match(
+      f.fingerprint as string,
+      /^[0-9a-f]{64}$/,
+      "each JSON finding carries a sha256 fingerprint",
+    );
+  }
+});
+
+test("toJson fingerprint is line-INSENSITIVE (a line move does not change it)", () => {
+  const base: Finding = {
+    ruleId: "node-crypto-ecdh",
+    title: "ECDH key exchange",
+    category: "key-exchange",
+    severity: "high",
+    confidence: "high",
+    algorithm: "ECDH",
+    hndl: true,
+    message: "ECDH is broken by Shor's algorithm.",
+    location: { file: "src/x.ts", line: 5, snippet: "createECDH('secp256k1')" },
+  };
+  // Same rule/path/snippet, only the line (and column) shifted.
+  const moved: Finding = {
+    ...base,
+    location: { ...base.location, line: 999, column: 40 },
+  };
+  const fpOf = (f: Finding) =>
+    (
+      toJson({ ...sampleResult(), findings: [f], inventory: buildInventory([f]) })
+        .findings as Array<Record<string, unknown>>
+    )[0].fingerprint as string;
+  assert.equal(fpOf(base), fpOf(moved), "fingerprint survives a line move");
+});
+
+test("toJson fingerprint differs across rule, path, and context", () => {
+  const base: Finding = {
+    ruleId: "node-crypto-ecdh",
+    title: "ECDH key exchange",
+    category: "key-exchange",
+    severity: "high",
+    confidence: "high",
+    algorithm: "ECDH",
+    hndl: true,
+    message: "ECDH is broken by Shor's algorithm.",
+    location: { file: "src/x.ts", line: 5, snippet: "createECDH('secp256k1')" },
+  };
+  const fpOf = (f: Finding) =>
+    (
+      toJson({ ...sampleResult(), findings: [f], inventory: buildInventory([f]) })
+        .findings as Array<Record<string, unknown>>
+    )[0].fingerprint as string;
+
+  const otherRule: Finding = { ...base, ruleId: "node-crypto-rsa" };
+  const otherPath: Finding = { ...base, location: { ...base.location, file: "src/y.ts" } };
+  const otherContext: Finding = {
+    ...base,
+    location: { ...base.location, snippet: "createECDH('prime256v1')" },
+  };
+
+  const fp = fpOf(base);
+  assert.notEqual(fpOf(otherRule), fp, "different rule → different fingerprint");
+  assert.notEqual(fpOf(otherPath), fp, "different path → different fingerprint");
+  assert.notEqual(fpOf(otherContext), fp, "different context → different fingerprint");
+});
+
+test("toJson fingerprint falls back to rule+path when no context is available", () => {
+  // No snippet: two findings that share rule+path collapse to one identity;
+  // changing the path (still no snippet) splits them apart again.
+  const noCtx: Finding = {
+    ruleId: "dep-vulnerable",
+    title: "Quantum-vulnerable dependency",
+    category: "dependency",
+    severity: "medium",
+    confidence: "high",
+    hndl: false,
+    message: "m",
+    location: { file: "package.json", line: 1 },
+  };
+  const fpOf = (f: Finding) =>
+    (
+      toJson({ ...sampleResult(), findings: [f], inventory: buildInventory([f]) })
+        .findings as Array<Record<string, unknown>>
+    )[0].fingerprint as string;
+
+  const sameNoLine: Finding = { ...noCtx, location: { ...noCtx.location, line: 42 } };
+  const otherPath: Finding = {
+    ...noCtx,
+    location: { ...noCtx.location, file: "sub/package.json" },
+  };
+  assert.equal(fpOf(noCtx), fpOf(sameNoLine), "rule+path identity survives line moves");
+  assert.notEqual(fpOf(noCtx), fpOf(otherPath), "rule+path still distinguishes different paths");
+});
+
+test("JSON fingerprint, SARIF partialFingerprints, and the baseline share one value", () => {
+  const f = sampleResult().findings[0];
+  const jsonFp = (
+    toJson({ ...sampleResult(), findings: [f], inventory: buildInventory([f]) }).findings as Array<
+      Record<string, unknown>
+    >
+  )[0].fingerprint as string;
+  const sarifFp = (
+    toSarif({ ...sampleResult(), findings: [f], inventory: buildInventory([f]) }).runs[0] as any
+  ).results[0].partialFingerprints["quantakrypto/v1"] as string;
+  const baselineFp = fingerprintFinding(f);
+  assert.equal(jsonFp, sarifFp, "JSON fingerprint equals SARIF partialFingerprint");
+  assert.equal(jsonFp, baselineFp, "JSON fingerprint equals the baseline identity");
+});
+
+test("toJson fingerprint is stable regardless of snippet redaction", () => {
+  const r = sampleResult();
+  const fpOf = (json: Record<string, unknown>) =>
+    (json.findings as Array<Record<string, unknown>>).map((f) => f.fingerprint as string);
+  assert.deepEqual(
+    fpOf(toJson(r)),
+    fpOf(toJson(r, { redactSnippets: true })),
+    "redacting the emitted snippet must not change identity",
+  );
 });
 
 test("formatSummary is plain text by default and colours on request", () => {


### PR DESCRIPTION
Roadmap initiative **1.a** — the substrate for posture drift, migration tracking, attestation, and HNDL exposure ranking.

Exposes the line-INSENSITIVE identity already used by the baseline (`sha256(ruleId | normalized-repo-relative-path | normalized-snippet)`, line number excluded, rule+path fallback) as a consumer-facing field:
- **JSON** (`--report json`): each finding gains a top-level `fingerprint` (64-char hex).
- **SARIF**: each result mirrors it in `properties.fingerprint`, alongside the existing `partialFingerprints["quantakrypto/v1"]`.

So JSON identity, SARIF fingerprints, and the baseline suppression set are one value; a line move does not change it. Reuses `fingerprintFinding` from the baseline module, **no public API change** (`api:check` passes), additive and backward compatible. The Action's new-vs-baseline discipline is untouched.

Verification: core 664/664 tests, qScan 153/153, typecheck clean, `api:check` green, prettier clean.

Downstream contract: the website posture ingest reads `finding.fingerprint` (JSON) / `properties.fingerprint` (SARIF).