### PR TITLE
Detection quick-wins: PHP composer, JS recall edges, npm v1/alias lockfiles, walk perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+### Added - detection quick-wins (PHP composer, JS recall edges, npm lockfile depth)
+
+Four post-1.0-roadmap accuracy/perf items on the benchmark-guarded detection
+surface. The F1 = 1.000 precision/recall benchmark is unchanged (still zero
+false positives, zero false negatives). SemVer: **minor** (additive detection).
+
+- **PHP `composer.json` / `composer.lock` dependency scanning**: a whole
+  ecosystem was invisible. Adds `composer` to `DependencyEcosystem`, a curated
+  DB of quantum-vulnerable PHP packages (phpseclib, paragonie/*, firebase/php-jwt,
+  lcobucci/jwt, web-token/jwt-framework, mdanter/ecc, simplito/elliptic-php), the
+  `composer.json` / `composer.lock` manifest mapping, and a generous
+  `vendor/package` extractor (both files are JSON, so the DB filter keeps it safe).
+- **JS home-turf recall edges**: the Node `crypto` detector now catches bracket
+  (computed-member) access, e.g. `crypto['createSign'](…)` /
+  `crypto["createECDH"](…)` / `crypto['generateKeyPairSync']('rsa')`, and
+  `generateKeyPair(kind, …)` where the key type is a variable (emitted as the
+  generic keygen rule, unknown family, HNDL-conservative). No double-counting
+  with the existing dotted-call and literal-argument rules.
+- **npm lockfile v1 nested tree + `npm:` alias resolution**: `scanNpmManifest`
+  now walks the legacy package-lock v1 nested `dependencies` tree (transitive
+  deps that never appear at the top level) and resolves `npm:`-aliased packages
+  from package.json values, v1 entry `version` fields, and v3 `packages` entry
+  `name` fields, so a vulnerable package hiding behind an alias is still flagged.
+- **Parallel-path double-stat elimination (perf)**: the directory walker now
+  surfaces the byte size it already stat'd (`walkFilesSized`), so the parallel
+  scanner no longer re-stats every file for byte-balanced chunking. Pure perf;
+  the file set and detection output are byte-identical.
+
 ### Added: stable finding fingerprints in JSON and SARIF output
 
 - Every finding in the `--report json` output now carries a top-level

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -448,6 +448,8 @@ function manifestEcosystem(file) {
     return "rubygems";
   if (base === "packages.config" || base === "directory.packages.props" || base.endsWith(".csproj"))
     return "nuget";
+  if (base === "composer.json" || base === "composer.lock")
+    return "composer";
   return null;
 }
 function isManifestFile(file) {
@@ -510,6 +512,12 @@ function candidateNames(ecosystem, content) {
         names.push(m[1]);
       }
       for (const m of content.matchAll(/<package\b[^>]*\bid\s*=\s*"([^"]+)"/gi)) {
+        names.push(m[1]);
+      }
+      break;
+    }
+    case "composer": {
+      for (const m of content.matchAll(/["']([a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)["']/gi)) {
         names.push(m[1]);
       }
       break;
@@ -582,6 +590,14 @@ function scanManifest(file, content) {
   }
   return sortByTitle(findings);
 }
+function npmAliasTarget(spec) {
+  if (!spec.startsWith("npm:"))
+    return null;
+  const rest = spec.slice(4);
+  const at = rest.lastIndexOf("@");
+  const name = at > 0 ? rest.slice(0, at) : rest;
+  return name || null;
+}
 function scanNpmManifest(content, file, db) {
   let json;
   try {
@@ -593,28 +609,47 @@ function scanNpmManifest(content, file, db) {
     return [];
   const found = /* @__PURE__ */ new Set();
   const obj = json;
-  const collectFromRecord = (rec) => {
-    if (rec === null || typeof rec !== "object")
+  const add = (name) => {
+    if (db.has(name))
+      found.add(name);
+  };
+  const walkDepTree = (deps, depth) => {
+    if (depth > NPM_TREE_MAX_DEPTH || deps === null || typeof deps !== "object")
       return;
-    for (const key of Object.keys(rec)) {
-      if (db.has(key))
-        found.add(key);
+    for (const [name, node] of Object.entries(deps)) {
+      add(name);
+      if (typeof node === "string") {
+        const aliased = npmAliasTarget(node);
+        if (aliased)
+          add(aliased);
+      } else if (node !== null && typeof node === "object") {
+        const rec = node;
+        if (typeof rec.version === "string") {
+          const aliased = npmAliasTarget(rec.version);
+          if (aliased)
+            add(aliased);
+        }
+        walkDepTree(rec.dependencies, depth + 1);
+      }
     }
   };
-  collectFromRecord(obj.dependencies);
-  collectFromRecord(obj.devDependencies);
-  collectFromRecord(obj.peerDependencies);
-  collectFromRecord(obj.optionalDependencies);
+  walkDepTree(obj.dependencies, 0);
+  walkDepTree(obj.devDependencies, 0);
+  walkDepTree(obj.peerDependencies, 0);
+  walkDepTree(obj.optionalDependencies, 0);
   const packages = obj.packages;
   if (packages !== null && typeof packages === "object") {
-    for (const key of Object.keys(packages)) {
+    for (const [key, entry] of Object.entries(packages)) {
       if (!key)
         continue;
       const marker = "node_modules/";
       const idx = key.lastIndexOf(marker);
-      const name = idx >= 0 ? key.slice(idx + marker.length) : key;
-      if (db.has(name))
-        found.add(name);
+      add(idx >= 0 ? key.slice(idx + marker.length) : key);
+      if (entry !== null && typeof entry === "object") {
+        const realName = entry.name;
+        if (typeof realName === "string")
+          add(realName);
+      }
     }
   }
   const findings = [];
@@ -650,7 +685,7 @@ function scanNpmLockfile(content, file, db) {
   }
   return sortByTitle(findings);
 }
-var DEP_VULNERABLE_RULE, vulnerableDependencies, BY_ECOSYSTEM, KEY_REGEX_BY_NAME;
+var DEP_VULNERABLE_RULE, vulnerableDependencies, BY_ECOSYSTEM, KEY_REGEX_BY_NAME, NPM_TREE_MAX_DEPTH;
 var init_dependencies = __esm({
   "../core/dist/dependencies.js"() {
     "use strict";
@@ -1258,6 +1293,73 @@ var init_dependencies = __esm({
         algorithms: ["RSA", "ECDSA"],
         severity: "medium",
         hndl: false
+      },
+      // --- Composer (PHP) ---
+      {
+        name: "phpseclib/phpseclib",
+        ecosystem: "composer",
+        reason: "Pure-PHP RSA / DSA / ECDSA / Diffie-Hellman public-key crypto and X.509.",
+        algorithms: ["RSA", "DSA", "ECDSA", "DH"],
+        severity: "high"
+      },
+      {
+        name: "paragonie/sodium_compat",
+        ecosystem: "composer",
+        reason: "Pure-PHP libsodium polyfill: X25519 key agreement and Ed25519 signatures.",
+        algorithms: ["X25519", "EdDSA"],
+        severity: "low"
+      },
+      {
+        name: "paragonie/halite",
+        ecosystem: "composer",
+        reason: "libsodium wrapper: X25519 key agreement and Ed25519 signatures.",
+        algorithms: ["X25519", "EdDSA"],
+        severity: "low"
+      },
+      {
+        name: "paragonie/paseto",
+        ecosystem: "composer",
+        reason: "PASETO public tokens signed with classical Ed25519 (v2/v4) or RSA.",
+        algorithms: ["EdDSA", "RSA"],
+        severity: "medium",
+        hndl: false
+      },
+      {
+        name: "firebase/php-jwt",
+        ecosystem: "composer",
+        reason: "PHP JWT signing/verification with classical RS*/ES* algorithms.",
+        algorithms: ["RSA", "ECDSA"],
+        severity: "medium",
+        hndl: false
+      },
+      {
+        name: "lcobucci/jwt",
+        ecosystem: "composer",
+        reason: "PHP JWT with classical RSA/ECDSA signature algorithms.",
+        algorithms: ["RSA", "ECDSA"],
+        severity: "medium",
+        hndl: false
+      },
+      {
+        name: "web-token/jwt-framework",
+        ecosystem: "composer",
+        reason: "JOSE (JWS/JWE) framework: classical RSA/ECDSA signatures and ECDH-ES key agreement.",
+        algorithms: ["RSA", "ECDSA", "ECDH"],
+        severity: "medium"
+      },
+      {
+        name: "mdanter/ecc",
+        ecosystem: "composer",
+        reason: "Pure-PHP elliptic-curve ECDSA signatures and ECDH key agreement.",
+        algorithms: ["ECDSA", "ECDH"],
+        severity: "high"
+      },
+      {
+        name: "simplito/elliptic-php",
+        ecosystem: "composer",
+        reason: "secp256k1 / NIST-curve ECDSA and ECDH in pure PHP (blockchain keys).",
+        algorithms: ["ECDSA", "ECDH"],
+        severity: "high"
       }
     ];
     BY_ECOSYSTEM = (() => {
@@ -1276,6 +1378,7 @@ var init_dependencies = __esm({
       const escaped = d.name.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
       return [d.name, new RegExp(`"${escaped}"\\s*:`)];
     }));
+    NPM_TREE_MAX_DEPTH = 64;
   }
 });
 
@@ -1397,6 +1500,10 @@ function looksMinified(content) {
   return avgLine > 1e3;
 }
 async function* walkFiles(root, options = {}) {
+  for await (const f of walkFilesSized(root, options))
+    yield f.rel;
+}
+async function* walkFilesSized(root, options = {}) {
   const include = options.include ?? [];
   const exclude = options.exclude ?? [];
   const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
@@ -1405,7 +1512,7 @@ async function* walkFiles(root, options = {}) {
   if (rootStat.isFile()) {
     const name = toPosix(path.basename(root));
     if (!isBinaryPath(name) && isIncluded(name, include) && passesSizeLimit(name, rootStat.size, maxFileSize)) {
-      yield name;
+      yield { rel: name, size: rootStat.size };
     }
     return;
   }
@@ -1449,14 +1556,16 @@ async function* walkDir(absDir, relDir, ctx) {
       continue;
     if (!manifest && isGeneratedPath(rel))
       continue;
+    let size;
     try {
       const s = await stat(abs);
       if (!passesSizeLimit(rel, s.size, ctx.maxFileSize))
         continue;
+      size = s.size;
     } catch {
       continue;
     }
-    yield rel;
+    yield { rel, size };
   }
 }
 var DEFAULT_IGNORES, DEFAULT_MAX_FILE_SIZE, BINARY_EXTENSIONS, GLOB_CACHE, KEYSTORE_EXTENSIONS, GENERATED_PATH_RE, MANIFEST_MAX_BYTES;
@@ -1977,13 +2086,14 @@ function isRealSshKeyOrAlgoList(content, index, matchLen) {
     distinct.add(t[1]);
   return distinct.size >= 2;
 }
-var RE_GENERATE_KEYPAIR, KEYGEN_INFO, ALIASABLE, RE_CREATE_SIGN_VERIFY, RE_ONESHOT_SIGN_VERIFY, RE_CREATE_DH, RE_GET_DH, RE_CREATE_ECDH, RE_RSA_ENCRYPT, RE_DH_KEYOBJECT, RE_WEBCRYPTO_ALGO, RE_SUBTLE_CALL, RE_FORGE_RSA, RE_FORGE_ED25519, RE_ELLIPTIC_EC, RE_JSRSASIGN_KEYGEN, RE_JSRSASIGN_SIGN, RE_NODE_RSA, RE_SECP256K1, RE_JWT_ALG, RE_JOSE_ECDH, RE_TLS_LEGACY_VERSION, RE_TLS_REJECT, RE_TLS_WEAK_CIPHER, RULE_NODE_KEYGEN, RULE_NODE_SIGN, RULE_NODE_SIGN_ONESHOT, RULE_NODE_DH, RULE_NODE_DH_MODP, RULE_NODE_ECDH, RULE_NODE_RSA_ENCRYPT, RULE_NODE_DH_KEYOBJECT, nodeCryptoDetector, RULE_WEBCRYPTO, webCryptoDetector, RULE_FORGE_RSA, RULE_FORGE_ED25519, RULE_ELLIPTIC_EC, RULE_SECP256K1, RULE_JSRSASIGN_KEYGEN, RULE_JSRSASIGN_SIGN, RULE_NODE_RSA_LIB, libraryDetector, RE_JOSE_KEM, RULE_JWT_ALG, RULE_JOSE_ECDH, RULE_JOSE_RSA_OAEP, jwtDetector, RULE_TLS_LEGACY, RULE_TLS_REJECT, RULE_TLS_WEAK_CIPHER, tlsDetector, RE_SSH_PUBKEY, RE_CERT_SIG_ALG, RE_SSH_KEX, RE_SSH_ALGO_TOKEN, SSH_LINE_WINDOW, RULE_SSH_PUBKEY, RULE_CERT_SIG_ALG, RULE_SSH_KEX, sshCertDetector, RE_TLS_CLASSICAL_KEX, RULE_TLS_CLASSICAL_KEX, tlsClassicalKexDetector, sourceDetectors;
+var RE_GENERATE_KEYPAIR, RE_GENERATE_KEYPAIR_VAR, KEYGEN_INFO, ALIASABLE, RE_CREATE_SIGN_VERIFY, RE_BRACKET_CRYPTO_METHOD, RE_BRACKET_KEYGEN, RE_ONESHOT_SIGN_VERIFY, RE_CREATE_DH, RE_GET_DH, RE_CREATE_ECDH, RE_RSA_ENCRYPT, RE_DH_KEYOBJECT, RE_WEBCRYPTO_ALGO, RE_SUBTLE_CALL, RE_FORGE_RSA, RE_FORGE_ED25519, RE_ELLIPTIC_EC, RE_JSRSASIGN_KEYGEN, RE_JSRSASIGN_SIGN, RE_NODE_RSA, RE_SECP256K1, RE_JWT_ALG, RE_JOSE_ECDH, RE_TLS_LEGACY_VERSION, RE_TLS_REJECT, RE_TLS_WEAK_CIPHER, RULE_NODE_KEYGEN, RULE_NODE_SIGN, RULE_NODE_SIGN_ONESHOT, RULE_NODE_DH, RULE_NODE_DH_MODP, RULE_NODE_ECDH, RULE_NODE_RSA_ENCRYPT, RULE_NODE_DH_KEYOBJECT, nodeCryptoDetector, RULE_WEBCRYPTO, webCryptoDetector, RULE_FORGE_RSA, RULE_FORGE_ED25519, RULE_ELLIPTIC_EC, RULE_SECP256K1, RULE_JSRSASIGN_KEYGEN, RULE_JSRSASIGN_SIGN, RULE_NODE_RSA_LIB, libraryDetector, RE_JOSE_KEM, RULE_JWT_ALG, RULE_JOSE_ECDH, RULE_JOSE_RSA_OAEP, jwtDetector, RULE_TLS_LEGACY, RULE_TLS_REJECT, RULE_TLS_WEAK_CIPHER, tlsDetector, RE_SSH_PUBKEY, RE_CERT_SIG_ALG, RE_SSH_KEX, RE_SSH_ALGO_TOKEN, SSH_LINE_WINDOW, RULE_SSH_PUBKEY, RULE_CERT_SIG_ALG, RULE_SSH_KEX, sshCertDetector, RE_TLS_CLASSICAL_KEX, RULE_TLS_CLASSICAL_KEX, tlsClassicalKexDetector, sourceDetectors;
 var init_source = __esm({
   "../core/dist/detectors/source.js"() {
     "use strict";
     init_detect_utils();
     init_cwe();
     RE_GENERATE_KEYPAIR = /generateKeyPair(?:Sync)?\s*\(\s*['"`](rsa-pss|rsa|ec|dsa|dh|x25519|x448|ed25519|ed448)['"`]/g;
+    RE_GENERATE_KEYPAIR_VAR = /(?<![\w$])generateKeyPair(?:Sync)?\s*\(\s*([A-Za-z_$][\w$]*)\s*[,)]/g;
     KEYGEN_INFO = {
       rsa: { algo: "RSA", cat: "kem", sev: "high", hndl: true, label: "RSA" },
       // RSA-PSS is signature-only, so classify it as a (forgeable) signature
@@ -2024,6 +2134,8 @@ var init_source = __esm({
       "createDiffieHellmanGroup"
     ];
     RE_CREATE_SIGN_VERIFY = /create(?:Sign|Verify)\s*\(/g;
+    RE_BRACKET_CRYPTO_METHOD = /\[\s*['"`](createSign|createVerify|createECDH|createDiffieHellman|createDiffieHellmanGroup|publicEncrypt|privateDecrypt)['"`]\s*\]\s*\(/g;
+    RE_BRACKET_KEYGEN = /\[\s*['"`]generateKeyPair(?:Sync)?['"`]\s*\]\s*\(\s*['"`](rsa-pss|rsa|ec|dsa|dh|x25519|x448|ed25519|ed448)['"`]/g;
     RE_ONESHOT_SIGN_VERIFY = /(?<![.\w])(?:crypto\.)?(sign|verify)\s*\(\s*(?:['"`][\w.-]+['"`]|null)\s*,/g;
     RE_CREATE_DH = /createDiffieHellman(?:Group)?\s*\(/g;
     RE_GET_DH = /getDiffieHellman\s*\(\s*['"`](modp\d+)['"`]\s*\)/g;
@@ -2163,6 +2275,15 @@ var init_source = __esm({
         eachMatch(RE_GENERATE_KEYPAIR, content, (m) => {
           pushKeygenFinding(findings, m[1], file, content, m.index, m[0].length);
         });
+        eachMatch(RE_GENERATE_KEYPAIR_VAR, content, (m) => {
+          findings.push(findingFromRule(RULE_NODE_KEYGEN, { file, content, index: m.index, matchLength: m[0].length }, {
+            title: "Classical key generation (variable key type)",
+            message: "Generates a classical asymmetric key pair (key type passed as a variable), which is not quantum-safe."
+          }));
+        });
+        eachMatch(RE_BRACKET_KEYGEN, content, (m) => {
+          pushKeygenFinding(findings, m[1], file, content, m.index, m[0].length);
+        });
         const aliases = collectCryptoAliases(content);
         for (const [canonical, names] of aliases) {
           for (const alias of names) {
@@ -2194,6 +2315,19 @@ var init_source = __esm({
             index: m.index,
             matchLength: m[0].length
           }));
+        });
+        eachMatch(RE_BRACKET_CRYPTO_METHOD, content, (m) => {
+          const loc = { file, content, index: m.index, matchLength: m[0].length };
+          const method = m[1];
+          if (method === "createSign" || method === "createVerify") {
+            findings.push(findingFromRule(RULE_NODE_SIGN, loc));
+          } else if (method === "createECDH") {
+            findings.push(findingFromRule(RULE_NODE_ECDH, loc));
+          } else if (method === "publicEncrypt" || method === "privateDecrypt") {
+            findings.push(findingFromRule(RULE_NODE_RSA_ENCRYPT, loc));
+          } else {
+            findings.push(findingFromRule(RULE_NODE_DH, loc));
+          }
         });
         eachMatch(RE_ONESHOT_SIGN_VERIFY, content, (m) => {
           findings.push(findingFromRule(RULE_NODE_SIGN_ONESHOT, {
@@ -9705,27 +9839,24 @@ function shouldParallelize(options, files) {
   return totalBytes >= byteFloor && files.length >= fileFloor;
 }
 async function enumerateFiles(options, baseDir) {
-  const rels = [];
-  if (options.files) {
-    for (const rel of filterExplicitFileList(options.files, options))
-      rels.push(rel);
-  } else {
-    for await (const rel of walkFiles(options.root, {
-      include: options.include,
-      exclude: options.exclude,
-      noDefaultIgnores: options.noDefaultIgnores,
-      maxFileSize: options.maxFileSize
-    })) {
-      rels.push(rel);
-    }
-  }
   const sized = [];
-  for (const rel of rels) {
-    let size = 0;
-    try {
-      size = (await stat3(path4.join(baseDir, ...rel.split("/")))).size;
-    } catch {
+  if (options.files) {
+    for (const rel of filterExplicitFileList(options.files, options)) {
+      let size = 0;
+      try {
+        size = (await stat3(path4.join(baseDir, ...rel.split("/")))).size;
+      } catch {
+      }
+      sized.push({ rel, size });
     }
+    return sized;
+  }
+  for await (const { rel, size } of walkFilesSized(options.root, {
+    include: options.include,
+    exclude: options.exclude,
+    noDefaultIgnores: options.noDefaultIgnores,
+    maxFileSize: options.maxFileSize
+  })) {
     sized.push({ rel, size });
   }
   return sized;

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -654,14 +654,83 @@ export const vulnerableDependencies: VulnerableDependency[] = [
     severity: "medium",
     hndl: false,
   },
+
+  // --- Composer (PHP) ---
+  {
+    name: "phpseclib/phpseclib",
+    ecosystem: "composer",
+    reason: "Pure-PHP RSA / DSA / ECDSA / Diffie-Hellman public-key crypto and X.509.",
+    algorithms: ["RSA", "DSA", "ECDSA", "DH"],
+    severity: "high",
+  },
+  {
+    name: "paragonie/sodium_compat",
+    ecosystem: "composer",
+    reason: "Pure-PHP libsodium polyfill: X25519 key agreement and Ed25519 signatures.",
+    algorithms: ["X25519", "EdDSA"],
+    severity: "low",
+  },
+  {
+    name: "paragonie/halite",
+    ecosystem: "composer",
+    reason: "libsodium wrapper: X25519 key agreement and Ed25519 signatures.",
+    algorithms: ["X25519", "EdDSA"],
+    severity: "low",
+  },
+  {
+    name: "paragonie/paseto",
+    ecosystem: "composer",
+    reason: "PASETO public tokens signed with classical Ed25519 (v2/v4) or RSA.",
+    algorithms: ["EdDSA", "RSA"],
+    severity: "medium",
+    hndl: false,
+  },
+  {
+    name: "firebase/php-jwt",
+    ecosystem: "composer",
+    reason: "PHP JWT signing/verification with classical RS*/ES* algorithms.",
+    algorithms: ["RSA", "ECDSA"],
+    severity: "medium",
+    hndl: false,
+  },
+  {
+    name: "lcobucci/jwt",
+    ecosystem: "composer",
+    reason: "PHP JWT with classical RSA/ECDSA signature algorithms.",
+    algorithms: ["RSA", "ECDSA"],
+    severity: "medium",
+    hndl: false,
+  },
+  {
+    name: "web-token/jwt-framework",
+    ecosystem: "composer",
+    reason: "JOSE (JWS/JWE) framework: classical RSA/ECDSA signatures and ECDH-ES key agreement.",
+    algorithms: ["RSA", "ECDSA", "ECDH"],
+    severity: "medium",
+  },
+  {
+    name: "mdanter/ecc",
+    ecosystem: "composer",
+    reason: "Pure-PHP elliptic-curve ECDSA signatures and ECDH key agreement.",
+    algorithms: ["ECDSA", "ECDH"],
+    severity: "high",
+  },
+  {
+    name: "simplito/elliptic-php",
+    ecosystem: "composer",
+    reason: "secp256k1 / NIST-curve ECDSA and ECDH in pure PHP (blockchain keys).",
+    algorithms: ["ECDSA", "ECDH"],
+    severity: "high",
+  },
 ];
 
 /**
  * Normalise a package name for matching within its ecosystem. PyPI is
  * case-insensitive and folds runs of `-_.` to a single `-` (PEP 503); cargo /
- * maven / rubygems / nuget are effectively lower-case (NuGet ids are matched
- * case-insensitively); npm and go module paths are matched verbatim (npm scopes
- * and go paths are case-sensitive).
+ * maven / rubygems / nuget / composer are effectively lower-case (NuGet ids are
+ * matched case-insensitively; Composer `vendor/package` names are lower-cased by
+ * Packagist); npm and go module paths are matched verbatim (npm scopes and go
+ * paths are case-sensitive).
  */
 function normalizeName(ecosystem: DependencyEcosystem, name: string): string {
   const n = name.trim();
@@ -749,6 +818,7 @@ export function manifestEcosystem(file: string): DependencyEcosystem | null {
   if (base === "gemfile" || base.endsWith(".gemspec")) return "rubygems";
   if (base === "packages.config" || base === "directory.packages.props" || base.endsWith(".csproj"))
     return "nuget";
+  if (base === "composer.json" || base === "composer.lock") return "composer";
   return null;
 }
 
@@ -824,6 +894,20 @@ function candidateNames(ecosystem: DependencyEcosystem, content: string): string
         names.push(m[1]);
       }
       for (const m of content.matchAll(/<package\b[^>]*\bid\s*=\s*"([^"]+)"/gi)) {
+        names.push(m[1]);
+      }
+      break;
+    }
+    case "composer": {
+      // composer.json `require`/`require-dev` maps are keyed by "vendor/package";
+      // composer.lock lists `{"name": "vendor/package", …}`. Both are JSON, so
+      // grab every quoted `vendor/package` token (a lower-case vendor + package
+      // separated by a single `/`). PHP platform requirements ("php", "ext-*")
+      // carry no slash and so are naturally excluded; the curated DB filters the
+      // rest, so over-capture is safe.
+      for (const m of content.matchAll(
+        /["']([a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)["']/gi,
+      )) {
         names.push(m[1]);
       }
       break;
@@ -925,9 +1009,32 @@ export function scanManifest(file: string, content: string): Finding[] {
 }
 
 /**
+ * Resolve an npm `npm:` alias spec to the real package it installs, or null when
+ * the spec is not an alias. An aliased dependency records the alias as the map
+ * KEY and `npm:<real-name>@<range>` as the VALUE (in package.json and in a
+ * lockfile entry's `version`), so the vulnerable package hides behind a benign
+ * alias name. Keeps a leading scope `@` (only a version `@` past index 0 is a
+ * separator): `npm:node-forge@^1` → `node-forge`, `npm:@scope/pkg@1` → `@scope/pkg`.
+ */
+function npmAliasTarget(spec: string): string | null {
+  if (!spec.startsWith("npm:")) return null;
+  const rest = spec.slice(4);
+  const at = rest.lastIndexOf("@");
+  const name = at > 0 ? rest.slice(0, at) : rest;
+  return name || null;
+}
+
+/** Guard against a pathological / hostile lockfile nesting the walk unbounded. */
+const NPM_TREE_MAX_DEPTH = 64;
+
+/**
  * npm manifest scan.
- * - `package.json`: dependencies / devDependencies / peerDependencies / optionalDependencies.
- * - `package-lock.json` (v2/v3): the `packages` map keys (node_modules/<name>).
+ * - `package.json`: dependencies / devDependencies / peerDependencies / optionalDependencies,
+ *   including `npm:`-aliased entries (the alias key hides the real package name).
+ * - `package-lock.json` v1: the NESTED `dependencies` tree, where each entry may carry
+ *   its own `dependencies` (transitive deps) and an `npm:` alias in `version`.
+ * - `package-lock.json` v2/v3: the flat `packages` map keys (node_modules/<name>),
+ *   plus each entry's own `name` field (set for aliased installs).
  */
 function scanNpmManifest(
   content: string,
@@ -945,26 +1052,54 @@ function scanNpmManifest(
   const found = new Set<string>();
   const obj = json as Record<string, unknown>;
 
-  const collectFromRecord = (rec: unknown): void => {
-    if (rec === null || typeof rec !== "object") return;
-    for (const key of Object.keys(rec as Record<string, unknown>)) {
-      if (db.has(key)) found.add(key);
+  const add = (name: string): void => {
+    if (db.has(name)) found.add(name);
+  };
+
+  /**
+   * Walk a dependency map that may be either a flat package.json map
+   * (name → version-range string) or a legacy package-lock v1 tree (name →
+   * `{ version, requires, dependencies }`, arbitrarily nested). Matches keys,
+   * resolves `npm:` aliases from string values and entry `version` fields, and
+   * recurses into a nested `dependencies` sub-tree.
+   */
+  const walkDepTree = (deps: unknown, depth: number): void => {
+    if (depth > NPM_TREE_MAX_DEPTH || deps === null || typeof deps !== "object") return;
+    for (const [name, node] of Object.entries(deps as Record<string, unknown>)) {
+      add(name);
+      if (typeof node === "string") {
+        // package.json form: the value is a range, possibly `npm:<real>@<range>`.
+        const aliased = npmAliasTarget(node);
+        if (aliased) add(aliased);
+      } else if (node !== null && typeof node === "object") {
+        const rec = node as Record<string, unknown>;
+        if (typeof rec.version === "string") {
+          const aliased = npmAliasTarget(rec.version);
+          if (aliased) add(aliased);
+        }
+        walkDepTree(rec.dependencies, depth + 1); // v1 nests transitive deps here
+      }
     }
   };
 
-  collectFromRecord(obj.dependencies);
-  collectFromRecord(obj.devDependencies);
-  collectFromRecord(obj.peerDependencies);
-  collectFromRecord(obj.optionalDependencies);
+  walkDepTree(obj.dependencies, 0);
+  walkDepTree(obj.devDependencies, 0);
+  walkDepTree(obj.peerDependencies, 0);
+  walkDepTree(obj.optionalDependencies, 0);
 
   const packages = obj.packages;
   if (packages !== null && typeof packages === "object") {
-    for (const key of Object.keys(packages as Record<string, unknown>)) {
+    for (const [key, entry] of Object.entries(packages as Record<string, unknown>)) {
       if (!key) continue; // root package entry
       const marker = "node_modules/";
       const idx = key.lastIndexOf(marker);
-      const name = idx >= 0 ? key.slice(idx + marker.length) : key;
-      if (db.has(name)) found.add(name);
+      add(idx >= 0 ? key.slice(idx + marker.length) : key);
+      // Aliased install: the entry's own `name` field is the real package, which
+      // differs from the alias embedded in the node_modules/<alias> key.
+      if (entry !== null && typeof entry === "object") {
+        const realName = (entry as Record<string, unknown>).name;
+        if (typeof realName === "string") add(realName);
+      }
     }
   }
 

--- a/packages/core/src/detectors/source.ts
+++ b/packages/core/src/detectors/source.ts
@@ -47,6 +47,15 @@ import { CWE_BROKEN_CRYPTO, CWE_CERT_VALIDATION, CWE_WEAK_STRENGTH } from "../cw
 // (ordered alternation would otherwise match `rsa` and reject the `-pss` tail).
 const RE_GENERATE_KEYPAIR =
   /generateKeyPair(?:Sync)?\s*\(\s*['"`](rsa-pss|rsa|ec|dsa|dh|x25519|x448|ed25519|ed448)['"`]/g;
+// Variable-typed key generation: `generateKeyPair(kind, …)` where the algorithm
+// argument is an IDENTIFIER (a variable), not a quoted literal, so the concrete
+// family is unknown at scan time but a classical key is still being generated.
+// The lookbehind anchors the call to a word boundary so it does not fire inside
+// a longer identifier (e.g. `myGenerateKeyPair(`); the first argument must be a
+// bare identifier immediately followed by `,` or `)` so a quoted-literal call
+// (handled by RE_GENERATE_KEYPAIR) never matches here.
+const RE_GENERATE_KEYPAIR_VAR =
+  /(?<![\w$])generateKeyPair(?:Sync)?\s*\(\s*([A-Za-z_$][\w$]*)\s*[,)]/g;
 
 /** Per-key-type classification for `generateKeyPair(Sync)('<type>', …)`. Hoisted
  * to module scope so the direct matcher AND the import-alias pass (below) share
@@ -177,6 +186,20 @@ function escapeRe(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 const RE_CREATE_SIGN_VERIFY = /create(?:Sign|Verify)\s*\(/g;
+// Computed-member (bracket) access to a Node `crypto` method:
+// `crypto['createSign'](…)`, `c["createECDH"](…)`. Bracket access defeats the
+// dotted-call regexes above (which require `name(`), so match a quoted method
+// name inside a `[ '…' ]( ` computed call and route it to the right rule. The
+// method names here take no key-type argument, so no argument parsing is needed;
+// `generateKeyPair(Sync)` bracket access is handled separately (it carries the
+// key-type literal). None of these overlap the dotted regexes (those require the
+// name immediately before `(`, whereas here it is followed by a closing quote).
+const RE_BRACKET_CRYPTO_METHOD =
+  /\[\s*['"`](createSign|createVerify|createECDH|createDiffieHellman|createDiffieHellmanGroup|publicEncrypt|privateDecrypt)['"`]\s*\]\s*\(/g;
+// `crypto['generateKeyPairSync']('rsa', …)`: bracket access carrying the quoted
+// key-type literal, classified exactly like the dotted `generateKeyPair` call.
+const RE_BRACKET_KEYGEN =
+  /\[\s*['"`]generateKeyPair(?:Sync)?['"`]\s*\]\s*\(\s*['"`](rsa-pss|rsa|ec|dsa|dh|x25519|x448|ed25519|ed448)['"`]/g;
 // One-shot crypto.sign/verify(algorithm, data, key). A LOOKBEHIND (not a
 // consumed char) anchors it so it doesn't fire inside identifiers like `assign(`
 // or `createSign(` (handled by the dedicated createSign/createVerify rule) —
@@ -375,6 +398,28 @@ const nodeCryptoDetector: Detector = {
       pushKeygenFinding(findings, m[1], file, content, m.index, m[0].length);
     });
 
+    // generateKeyPair(Sync)(<variable>, …): key type passed as a variable, so the
+    // family is unknown; emit the generic keygen rule (unknown / key-exchange /
+    // HNDL-conservative) rather than missing the classical key generation.
+    eachMatch(RE_GENERATE_KEYPAIR_VAR, content, (m) => {
+      findings.push(
+        findingFromRule(
+          RULE_NODE_KEYGEN,
+          { file, content, index: m.index, matchLength: m[0].length },
+          {
+            title: "Classical key generation (variable key type)",
+            message:
+              "Generates a classical asymmetric key pair (key type passed as a variable), which is not quantum-safe.",
+          },
+        ),
+      );
+    });
+
+    // Bracket (computed-member) key generation: crypto['generateKeyPairSync']('rsa').
+    eachMatch(RE_BRACKET_KEYGEN, content, (m) => {
+      pushKeygenFinding(findings, m[1], file, content, m.index, m[0].length);
+    });
+
     // Import-alias resolution: follow `import { generateKeyPairSync as gk }` (and
     // the CommonJS destructure-rename) so an aliased call still detects. Only the
     // keygen / ECDH / DH constructors are resolved — their classification is
@@ -430,6 +475,23 @@ const nodeCryptoDetector: Detector = {
           matchLength: m[0].length,
         }),
       );
+    });
+
+    // Bracket (computed-member) access to argument-free crypto methods:
+    // crypto['createSign'](…), c["createECDH"](…). Route each to its rule.
+    eachMatch(RE_BRACKET_CRYPTO_METHOD, content, (m) => {
+      const loc = { file, content, index: m.index, matchLength: m[0].length };
+      const method = m[1];
+      if (method === "createSign" || method === "createVerify") {
+        findings.push(findingFromRule(RULE_NODE_SIGN, loc));
+      } else if (method === "createECDH") {
+        findings.push(findingFromRule(RULE_NODE_ECDH, loc));
+      } else if (method === "publicEncrypt" || method === "privateDecrypt") {
+        findings.push(findingFromRule(RULE_NODE_RSA_ENCRYPT, loc));
+      } else {
+        // createDiffieHellman / createDiffieHellmanGroup: finite-field DH.
+        findings.push(findingFromRule(RULE_NODE_DH, loc));
+      }
     });
 
     // One-shot crypto.sign(algorithm, data, key) / crypto.verify(...) (Node ≥ 12).

--- a/packages/core/src/parallel.ts
+++ b/packages/core/src/parallel.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import type { Worker as NodeWorker } from "node:worker_threads";
 
 import type { Finding, ParallelScanOptions, ScanResult } from "./types.js";
-import { walkFiles } from "./walk.js";
+import { walkFilesSized } from "./walk.js";
 import { isAnalyzableSource } from "./detect-utils.js";
 import { buildInventory } from "./inventory.js";
 import { compareFindings, filterExplicitFileList, scan } from "./scan.js";
@@ -115,30 +115,31 @@ function shouldParallelize(options: ParallelScanOptions, files: SizedFile[]): bo
  * explicit `files` list or the walker. Sizes power byte-balanced chunking.
  */
 async function enumerateFiles(options: ParallelScanOptions, baseDir: string): Promise<SizedFile[]> {
-  const rels: string[] = [];
+  const sized: SizedFile[] = [];
   if (options.files) {
+    // Explicit file list: the walker isn't involved, so stat each once here.
     // Apply the SAME include/exclude/binary filtering the serial path uses via
-    // `filterExplicitFiles`, so `--parallel` is byte-for-byte identical to serial.
-    for (const rel of filterExplicitFileList(options.files, options)) rels.push(rel);
-  } else {
-    for await (const rel of walkFiles(options.root, {
-      include: options.include,
-      exclude: options.exclude,
-      noDefaultIgnores: options.noDefaultIgnores,
-      maxFileSize: options.maxFileSize,
-    })) {
-      rels.push(rel);
+    // `filterExplicitFileList`, so `--parallel` is byte-for-byte identical to serial.
+    for (const rel of filterExplicitFileList(options.files, options)) {
+      let size = 0;
+      try {
+        size = (await stat(path.join(baseDir, ...rel.split("/")))).size;
+      } catch {
+        // Unreadable now; keep with size 0 (the worker read will skip if it's gone).
+      }
+      sized.push({ rel, size });
     }
+    return sized;
   }
 
-  const sized: SizedFile[] = [];
-  for (const rel of rels) {
-    let size = 0;
-    try {
-      size = (await stat(path.join(baseDir, ...rel.split("/")))).size;
-    } catch {
-      // Unreadable now; keep with size 0 — worker read will skip if it's gone.
-    }
+  // Directory walk: reuse the size the walker already stat'd while enforcing the
+  // size limit, so files are not stat'd a second time here (double-stat fix).
+  for await (const { rel, size } of walkFilesSized(options.root, {
+    include: options.include,
+    exclude: options.exclude,
+    noDefaultIgnores: options.noDefaultIgnores,
+    maxFileSize: options.maxFileSize,
+  })) {
     sized.push({ rel, size });
   }
   return sized;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,7 +95,15 @@ export interface Finding {
 }
 
 /** Package ecosystems the dependency scanner understands. */
-export type DependencyEcosystem = "npm" | "pypi" | "cargo" | "go" | "maven" | "rubygems" | "nuget";
+export type DependencyEcosystem =
+  | "npm"
+  | "pypi"
+  | "cargo"
+  | "go"
+  | "maven"
+  | "rubygems"
+  | "nuget"
+  | "composer";
 
 /** A known quantum-vulnerable dependency entry. */
 export interface VulnerableDependency {

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -291,12 +291,34 @@ export function looksMinified(content: string): boolean {
   return avgLine > 1_000;
 }
 
+/** A scannable file plus the byte size the walker already stat'd for it. */
+export interface WalkedFile {
+  /** Relative POSIX path from the walk root. */
+  rel: string;
+  /** File size in bytes (from the walker's own stat; never re-stat downstream). */
+  size: number;
+}
+
 /**
  * Recursively yield scannable file paths (relative to `root`, POSIX) under a
  * directory. If `root` points at a single file, yields just that file's
- * basename (subject to the size / binary filters).
+ * basename (subject to the size / binary filters). Thin wrapper over
+ * {@link walkFilesSized} that drops the size (the historical string-yielding API).
  */
 export async function* walkFiles(root: string, options: WalkOptions = {}): AsyncGenerator<string> {
+  for await (const f of walkFilesSized(root, options)) yield f.rel;
+}
+
+/**
+ * Like {@link walkFiles} but yields each file WITH the byte size the walker
+ * already obtained while applying the size limit. Callers that need sizes (the
+ * parallel scanner's byte-balanced chunking) consume this directly so they do
+ * not stat every file a second time (P2 double-stat elimination).
+ */
+export async function* walkFilesSized(
+  root: string,
+  options: WalkOptions = {},
+): AsyncGenerator<WalkedFile> {
   const include = options.include ?? [];
   const exclude = options.exclude ?? [];
   const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
@@ -312,7 +334,7 @@ export async function* walkFiles(root: string, options: WalkOptions = {}): Async
       isIncluded(name, include) &&
       passesSizeLimit(name, rootStat.size, maxFileSize)
     ) {
-      yield name;
+      yield { rel: name, size: rootStat.size };
     }
     return;
   }
@@ -349,7 +371,11 @@ export function passesSizeLimit(rel: string, size: number, maxFileSize: number):
 }
 
 /** Internal recursive directory walker. `relDir` is POSIX-relative to the root. */
-async function* walkDir(absDir: string, relDir: string, ctx: WalkContext): AsyncGenerator<string> {
+async function* walkDir(
+  absDir: string,
+  relDir: string,
+  ctx: WalkContext,
+): AsyncGenerator<WalkedFile> {
   let entries: Dirent[];
   try {
     entries = await readdir(absDir, { withFileTypes: true });
@@ -386,13 +412,15 @@ async function* walkDir(absDir: string, relDir: string, ctx: WalkContext): Async
     if (!manifest && isBinaryPath(rel)) continue;
     if (!manifest && isGeneratedPath(rel)) continue;
 
+    let size: number;
     try {
       const s = await stat(abs);
       if (!passesSizeLimit(rel, s.size, ctx.maxFileSize)) continue;
+      size = s.size;
     } catch {
       continue;
     }
 
-    yield rel;
+    yield { rel, size };
   }
 }

--- a/packages/core/test/dependencies.test.ts
+++ b/packages/core/test/dependencies.test.ts
@@ -9,7 +9,16 @@ import { scanManifest, isManifestFile } from "../src/dependencies.js";
 
 test("database has a healthy number of curated entries across ecosystems", () => {
   assert.ok(vulnerableDependencies.length >= 15, "at least 15 curated entries");
-  const validEcosystems = new Set(["npm", "pypi", "cargo", "go", "maven", "rubygems", "nuget"]);
+  const validEcosystems = new Set([
+    "npm",
+    "pypi",
+    "cargo",
+    "go",
+    "maven",
+    "rubygems",
+    "nuget",
+    "composer",
+  ]);
   const ecosystems = new Set<string>();
   for (const d of vulnerableDependencies) {
     assert.ok(validEcosystems.has(d.ecosystem), `${d.name}: valid ecosystem`);
@@ -19,7 +28,7 @@ test("database has a healthy number of curated entries across ecosystems", () =>
     assert.ok(d.reason.length > 0);
   }
   // Multi-ecosystem coverage — not just npm anymore.
-  for (const eco of ["npm", "pypi", "cargo", "go", "maven", "rubygems", "nuget"]) {
+  for (const eco of ["npm", "pypi", "cargo", "go", "maven", "rubygems", "nuget", "composer"]) {
     assert.ok(ecosystems.has(eco), `database covers ${eco}`);
   }
 });
@@ -37,6 +46,8 @@ test("isManifestFile recognises manifests across ecosystems", () => {
     "build.gradle",
     "Gemfile",
     "lib/foo.gemspec",
+    "composer.json",
+    "app/composer.lock",
   ]) {
     assert.equal(isManifestFile(f), true, `${f} is a manifest`);
   }
@@ -146,6 +157,51 @@ test("rubygems Gemfile gem lines are matched", () => {
       (f) => f.title === "Quantum-vulnerable dependency: rails",
     ),
   );
+});
+
+test("composer.json require/require-dev vendor/package names are matched", () => {
+  const composer = JSON.stringify({
+    name: "acme/app",
+    require: {
+      php: ">=8.1",
+      "ext-openssl": "*",
+      "phpseclib/phpseclib": "^3.0",
+      "firebase/php-jwt": "^6.0",
+      "monolog/monolog": "^3.0",
+    },
+    "require-dev": {
+      "paragonie/halite": "^5.0",
+    },
+  });
+  assertFlags("composer.json", composer, [
+    "phpseclib/phpseclib",
+    "firebase/php-jwt",
+    "paragonie/halite",
+  ]);
+  // Platform reqs and a non-crypto package must not be flagged.
+  const findings = scanManifest("composer.json", composer);
+  assert.ok(!findings.some((f) => f.title.includes("monolog")));
+  assert.ok(!findings.some((f) => f.title.includes("ext-openssl")));
+});
+
+test("composer.lock packages array is parsed", () => {
+  const lock = JSON.stringify({
+    "content-hash": "abc",
+    packages: [
+      { name: "mdanter/ecc", version: "1.0.0" },
+      { name: "psr/log", version: "3.0.0" },
+    ],
+    "packages-dev": [{ name: "simplito/elliptic-php", version: "1.0.6" }],
+  });
+  assertFlags("composer.lock", lock, ["mdanter/ecc", "simplito/elliptic-php"]);
+  assert.ok(!scanManifest("composer.lock", lock).some((f) => f.title.includes("psr/log")));
+});
+
+test("composer: phpseclib exposes RSA/DH so it is HNDL-exposed", () => {
+  const composer = JSON.stringify({ require: { "phpseclib/phpseclib": "^3.0" } });
+  const f = scanManifest("composer.json", composer)[0];
+  assert.equal(f.ruleId, "dep-vulnerable");
+  assert.equal(f.hndl, true);
 });
 
 test("ecosystem scoping: a same-named package matches only its ecosystem", () => {

--- a/packages/core/test/lockfiles.test.ts
+++ b/packages/core/test/lockfiles.test.ts
@@ -61,3 +61,69 @@ test("a lockfile with no known-vulnerable deps yields nothing", () => {
   const yarn = ["lodash@^4.17.21:", '  version "4.17.21"'].join("\n");
   assert.deepEqual(scanManifest("yarn.lock", yarn), []);
 });
+
+test("package-lock v1 nested dependencies tree: a transitive vulnerable dep is flagged", () => {
+  // Legacy v1 lockfile: `elliptic` appears ONLY nested under a top-level dep's
+  // own `dependencies` tree, never at the top level. The recursive walk must find it.
+  const lock = JSON.stringify({
+    name: "demo",
+    lockfileVersion: 1,
+    dependencies: {
+      "some-wrapper": {
+        version: "1.0.0",
+        requires: { elliptic: "^6.5.4" },
+        dependencies: {
+          elliptic: { version: "6.5.4", resolved: "https://registry/elliptic-6.5.4.tgz" },
+          "safe-buffer": { version: "5.2.1" },
+        },
+      },
+    },
+  });
+  const findings = scanManifest("package-lock.json", lock);
+  assert.ok(
+    findings.some((f) => f.title.includes("elliptic")),
+    "nested transitive elliptic flagged",
+  );
+  assert.ok(!findings.some((f) => f.title.includes("safe-buffer")));
+});
+
+test("npm: alias in package.json resolves to the real (vulnerable) package", () => {
+  // The alias key `my-forge` hides `node-forge`; resolution must see through it.
+  const pkg = JSON.stringify({
+    dependencies: { "my-forge": "npm:node-forge@^1.3.0", left: "^1.0.0" },
+  });
+  const findings = scanManifest("package.json", pkg);
+  assert.ok(findings.some((f) => f.title.includes("node-forge")));
+});
+
+test("npm: scoped alias keeps the leading scope", () => {
+  const pkg = JSON.stringify({
+    dependencies: { curves: "npm:@noble/curves@^1.2.0" },
+  });
+  const findings = scanManifest("package.json", pkg);
+  assert.ok(findings.some((f) => f.title.includes("@noble/curves")));
+});
+
+test("package-lock v1 npm: alias in a nested entry version resolves", () => {
+  const lock = JSON.stringify({
+    lockfileVersion: 1,
+    dependencies: {
+      "my-forge": { version: "npm:node-forge@1.3.1" },
+    },
+  });
+  assert.ok(scanManifest("package-lock.json", lock).some((f) => f.title.includes("node-forge")));
+});
+
+test("package-lock v3 aliased install: the entry's name field resolves", () => {
+  const lock = JSON.stringify({
+    lockfileVersion: 3,
+    packages: {
+      "": { name: "demo" },
+      "node_modules/my-forge": { name: "node-forge", version: "1.3.1" },
+      "node_modules/lodash": { version: "4.17.21" },
+    },
+  });
+  const findings = scanManifest("package-lock.json", lock);
+  assert.ok(findings.some((f) => f.title.includes("node-forge")));
+  assert.ok(!findings.some((f) => f.title.includes("lodash")));
+});

--- a/packages/core/test/source-recall-edge.test.ts
+++ b/packages/core/test/source-recall-edge.test.ts
@@ -1,0 +1,80 @@
+/**
+ * JS home-turf recall edge cases for the Node `crypto` detector: bracket
+ * (computed-member) access to crypto methods, and `generateKeyPair` called with
+ * a variable key type instead of a quoted literal. These forms defeat the
+ * dotted-call / literal-argument regexes, so they are asserted directly here.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { detectors } from "../src/index.js";
+import type { Finding } from "../src/index.js";
+
+function run(file: string, content: string): Finding[] {
+  const out: Finding[] = [];
+  for (const det of detectors) {
+    if (det.appliesTo(file)) out.push(...det.detect({ file, content }));
+  }
+  return out;
+}
+function rule(findings: Finding[], id: string): Finding | undefined {
+  return findings.find((f) => f.ruleId === id);
+}
+
+test("crypto['createSign'] bracket access is detected as a classical signature", () => {
+  const f = rule(run("a.js", "const s = crypto['createSign']('RSA-SHA256');"), "node-crypto-sign");
+  assert.ok(f, "bracket createSign flagged");
+  assert.equal(f?.category, "signature");
+});
+
+test("bracket access to createVerify / createECDH / DH / RSA encrypt is routed correctly", () => {
+  assert.ok(rule(run("a.js", 'crypto["createVerify"]("RSA-SHA256")'), "node-crypto-sign"));
+  assert.ok(rule(run("a.js", "crypto['createECDH']('secp256k1')"), "node-crypto-ecdh"));
+  assert.ok(rule(run("a.js", "crypto['createDiffieHellman'](2048)"), "node-crypto-dh"));
+  assert.ok(rule(run("a.js", "crypto['publicEncrypt'](key, buf)"), "node-crypto-rsa-encrypt"));
+  assert.ok(rule(run("a.js", "crypto['privateDecrypt'](key, buf)"), "node-crypto-rsa-encrypt"));
+});
+
+test("bracket createSign is not double-counted by the dotted-call rule", () => {
+  const signs = run("a.js", "crypto['createSign']('RSA-SHA256')").filter(
+    (f) => f.ruleId === "node-crypto-sign",
+  );
+  assert.equal(signs.length, 1);
+});
+
+test("generateKeyPair with a variable key type is detected (unknown family)", () => {
+  const f = rule(
+    run("a.js", "const kind = 'rsa';\ncrypto.generateKeyPairSync(kind, opts);"),
+    "node-crypto-keygen",
+  );
+  assert.ok(f, "variable-typed generateKeyPair flagged");
+  assert.equal(f?.algorithm, "unknown");
+  assert.equal(f?.hndl, true);
+  assert.ok(f?.title.includes("variable"));
+});
+
+test("bracket generateKeyPair with a literal key type keeps its concrete family", () => {
+  const f = rule(
+    run("a.js", "crypto['generateKeyPairSync']('rsa', { modulusLength: 2048 });"),
+    "node-crypto-keygen",
+  );
+  assert.ok(f);
+  assert.equal(f?.algorithm, "RSA");
+});
+
+test("a literal generateKeyPair call is NOT also matched by the variable-typed rule", () => {
+  const keygens = run("a.js", "crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' })").filter(
+    (f) => f.ruleId === "node-crypto-keygen",
+  );
+  assert.equal(keygens.length, 1);
+  assert.equal(keygens[0].algorithm, "ECDH");
+});
+
+test("a similarly-named function does not misfire the variable-typed keygen rule", () => {
+  // `myGenerateKeyPair(kind)` is not Node's crypto API; the word boundary guard
+  // must keep it from matching.
+  const keygens = run("a.js", "myGenerateKeyPair(kind);").filter(
+    (f) => f.ruleId === "node-crypto-keygen",
+  );
+  assert.equal(keygens.length, 0);
+});

--- a/packages/core/test/walk.test.ts
+++ b/packages/core/test/walk.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 
 import { walkFiles } from "../src/index.js";
-import { passesSizeLimit, MANIFEST_MAX_BYTES } from "../src/walk.js";
+import { passesSizeLimit, MANIFEST_MAX_BYTES, walkFilesSized } from "../src/walk.js";
 
 /** Collect an async iterator into a sorted array. */
 async function collect(iter: AsyncIterable<string>): Promise<string[]> {
@@ -55,6 +55,24 @@ test("walkFiles skips default ignores and binaries", async () => {
     assert.deepEqual(files, ["a.ts", "legacy/old.ts", "src/b.js"]);
     assert.ok(!files.includes("logo.png"), "binary extension skipped");
     assert.ok(!files.some((f) => f.startsWith("node_modules/")), "node_modules ignored");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("walkFilesSized yields the same files with their byte sizes (single stat)", async () => {
+  const dir = await makeTree();
+  try {
+    const sized: { rel: string; size: number }[] = [];
+    for await (const f of walkFilesSized(dir)) sized.push(f);
+    const rels = sized.map((f) => f.rel).sort();
+    // Same file set as walkFiles (walkFiles is now a thin wrapper over this).
+    assert.deepEqual(rels, ["a.ts", "legacy/old.ts", "src/b.js"]);
+    // `a.ts` content is "export const a = 1;\n" (20 bytes), and the walker reports it
+    // from its own stat, so downstream never needs a second stat.
+    const a = sized.find((f) => f.rel === "a.ts");
+    assert.equal(a?.size, 20);
+    for (const f of sized) assert.ok(f.size >= 0, `${f.rel} has a size`);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Four items from the post-1.0 code roadmap, all under the F1=1.000 gate.

1. **PHP composer.json/lock** dependency scanning (9 curated quantum-vulnerable PHP packages; new `composer` ecosystem).
2. **JS recall edges**: bracket/computed access (`crypto['createSign']`) and variable-typed `generateKeyPair`, routed to the right rules with no double-count.
3. **npm lockfile v1 nested tree + `npm:` alias** resolution (package.json, v1 version fields, v3 packages names; depth-guarded).
4. **Parallel-path double-`stat` fix**: `walkFilesSized` surfaces the size the walker already stat'd; detection output byte-identical.

Benchmark: **159 TP / 0 FP / 0 FN, F1 1.000 before and after** (no regression, no new false positives). Full gate green (1178 tests, typecheck, lint, api:check unchanged, format). Action dist rebuilt. Zero-dep, offline boundary intact. Manual-merge per repo guardrail.