### PR TITLE
release: 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,11 +2184,11 @@
     },
     "packages/action": {
       "name": "@quantakrypto/action",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.5.0",
-        "@quantakrypto/qscan": "0.5.0"
+        "@quantakrypto/core": "0.6.0",
+        "@quantakrypto/qscan": "0.6.0"
       },
       "devDependencies": {
         "esbuild": "0.28.1"
@@ -2199,10 +2199,10 @@
     },
     "packages/agent": {
       "name": "@quantakrypto/agent",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.5.0"
+        "@quantakrypto/core": "0.6.0"
       },
       "engines": {
         "node": ">=20"
@@ -2210,7 +2210,7 @@
     },
     "packages/core": {
       "name": "@quantakrypto/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -2218,11 +2218,11 @@
     },
     "packages/mcp": {
       "name": "@quantakrypto/mcp",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.5.0",
-        "@quantakrypto/qprobe": "0.5.0"
+        "@quantakrypto/core": "0.6.0",
+        "@quantakrypto/qprobe": "0.6.0"
       },
       "bin": {
         "quantakrypto-mcp": "dist/stdio.js"
@@ -2246,10 +2246,10 @@
     },
     "packages/qprobe": {
       "name": "@quantakrypto/qprobe",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.5.0"
+        "@quantakrypto/core": "0.6.0"
       },
       "bin": {
         "qprobe": "dist/cli.js"
@@ -2260,11 +2260,11 @@
     },
     "packages/qscan": {
       "name": "@quantakrypto/qscan",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/agent": "0.5.0",
-        "@quantakrypto/core": "0.5.0"
+        "@quantakrypto/agent": "0.6.0",
+        "@quantakrypto/core": "0.6.0"
       },
       "bin": {
         "qremediate": "dist/remediate-bin.js",
@@ -2276,7 +2276,7 @@
     },
     "packages/sieve": {
       "name": "@quantakrypto/sieve",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "bin": {
         "sieve": "dist/cli.js"

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -26,7 +26,7 @@ var VERSION;
 var init_version = __esm({
   "../core/dist/version.js"() {
     "use strict";
-    VERSION = "0.5.0";
+    VERSION = "0.6.0";
   }
 });
 

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/action",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "quantakrypto Action — fail CI when new quantum-vulnerable cryptography lands. GitHub Action wrapping qScan.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -25,8 +25,8 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.5.0",
-    "@quantakrypto/qscan": "0.5.0"
+    "@quantakrypto/core": "0.6.0",
+    "@quantakrypto/qscan": "0.6.0"
   },
   "devDependencies": {
     "esbuild": "0.28.1"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/agent",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "BYOK LLM client for qScan triage and remediation. Native fetch, zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.5.0"
+    "@quantakrypto/core": "0.6.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared post-quantum readiness library: crypto detectors, vulnerable-dependency database, inventory + SARIF reporting. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -3,4 +3,4 @@
  * the scan orchestrator can import it without creating a cycle through index.ts.
  * Keep in sync with packages/core/package.json.
  */
-export const VERSION = "0.5.0";
+export const VERSION = "0.6.0";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/mcp",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "mcpName": "io.github.quantakrypto/pqc-tools",
   "description": "quantakrypto MCP — post-quantum readiness for AI coding agents via the Model Context Protocol. Zero runtime dependencies (stdio JSON-RPC implemented in-house).",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.5.0",
-    "@quantakrypto/qprobe": "0.5.0"
+    "@quantakrypto/core": "0.6.0",
+    "@quantakrypto/qprobe": "0.6.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/package.json
+++ b/packages/qprobe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qprobe",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "qProbe — actively inspect live TLS/SSH endpoints you OWN for post-quantum readiness (hybrid KEX, classical certs). Gated behind an ownership attestation. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.5.0"
+    "@quantakrypto/core": "0.6.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/src/version.ts
+++ b/packages/qprobe/src/version.ts
@@ -1,2 +1,2 @@
 /** qProbe version, surfaced in JSON output. Keep in sync with package.json. */
-export const VERSION = "0.5.0";
+export const VERSION = "0.6.0";

--- a/packages/qscan/package.json
+++ b/packages/qscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qscan",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "qScan — find quantum-vulnerable cryptography in any codebase (CLI). Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,8 +37,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/agent": "0.5.0",
-    "@quantakrypto/core": "0.5.0"
+    "@quantakrypto/agent": "0.6.0",
+    "@quantakrypto/core": "0.6.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/sieve/package.json
+++ b/packages/sieve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/sieve",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Sieve — conformance battery for ML-KEM / ML-DSA implementations. Drives any implementation over a simple stdin/stdout JSON protocol. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",


### PR DESCRIPTION
Coordinated **0.6.0** minor across the published packages (core, qscan, mcp, qprobe, sieve, agent; action stays tag-shipped/private). Ships everything that landed since 0.5.0:

- **HNDL data-risk quantifier** (#37) — `hndl.yml`, `qscan --hndl`, `hndl init`.
- **crypto-agility manifest** (#40) — `qscan crypto-agility emit` + `qscan crypto-agility validate`, the well-known posture document behind draft-acosta-crypto-agility-manifest.

Mechanical: every package version → 0.6.0, exact internal dep pins updated to match, `version.ts` constants bumped, lockfile synced, action dist re-bundled.

## Why now
The website needs the published emitter to auto-generate quantakrypto.com's own `/.well-known/crypto-agility.json` in CI (`npx @quantakrypto/qscan crypto-agility emit`). Publishing also puts the emitter + validator the IETF draft references into users' hands.

## Gates (all green locally)
format · build · action bundle fresh · test (incl. detection F1) · lint · format:check · perf bench (both paths agree on 834 findings).

## Publish
After merge: cut a GitHub Release `v0.6.0` (or run `release.yml` with confirm=publish). The workflow publishes each package with provenance, skipping any version already on npm.