### PR TITLE
qprobe: refuse a URL as a URL, not as a CIDR block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+### Fixed - qProbe: a URL target is refused as a URL, not as a CIDR block
+
+`qprobe --i-own-this https://example.com` failed with
+`refusing CIDR block "https://example.com" — qProbe probes one host at a time,
+not ranges.` The slash check ran before anything else, so every URL was reported
+as a range sweep: an error describing a mistake the operator had not made, and
+one that gave no hint about the fix. SemVer: **patch** (message and
+classification only; nothing newly accepted, nothing newly refused).
+
+URLs are still refused — a target is one named host — but now for the right
+reason, and the message names the host to use:
+
+```
+refusing URL "https://example.com/health" — qProbe takes a host, not a URL. Try: example.com
+```
+
+- A slash is only reported as a **CIDR block** when it is actually a prefix
+  length (`10.0.0.0/24`). A pasted path (`example.com/blog`) says so instead.
+- A target carrying **credentials** (`mine.com@theirs.com`) is refused
+  explicitly, and the suggestion names the host it would really have connected
+  to. `--i-own-this` is an ownership attestation, so a target that reads as one
+  host and resolves to another cannot be accepted quietly.
+- The refusals that are security controls are unchanged: CIDR blocks, IP ranges,
+  wildcards and lists still throw before any network I/O.
+
 ### Fixed - Sieve: an implementation that cannot be run is no longer reported as a failing implementation
 
 Pointing `--impl` at a command that does not exist produced a **FAIL** report

--- a/packages/qprobe/README.md
+++ b/packages/qprobe/README.md
@@ -12,7 +12,8 @@ before using it.
 
 > **Authorization required.** qProbe sends nothing until you attest you are
 > authorized to test the target. Active probing of endpoints you do not own may be
-> unlawful. qProbe refuses CIDR blocks, IP ranges, wildcards, and target lists — it
+> unlawful. A target is one host or `host:port` (`api.example.com`), never a URL.
+> qProbe refuses CIDR blocks, IP ranges, wildcards, and target lists — it
 > probes **one host you operate** at a time, and it only ever performs a benign,
 > unauthenticated handshake. It reports the negotiated reality; it never modifies an
 > endpoint ("engine disposes").

--- a/packages/qprobe/src/args.ts
+++ b/packages/qprobe/src/args.ts
@@ -94,6 +94,7 @@ AUTHORIZATION (required — one of)
   --i-own-this            Attest you are authorized to probe the given endpoint(s).
   --owned-hosts <file>    Ownership manifest (one host per line, # comments).
 
+  A target is one host or host:port, e.g. api.example.com — not a URL.
   Active probing of endpoints you do not own may be unlawful. qprobe refuses CIDR
   blocks, IP ranges, wildcards and target lists. See THREAT-MODEL.md.
 

--- a/packages/qprobe/src/target.ts
+++ b/packages/qprobe/src/target.ts
@@ -22,6 +22,30 @@ export class TargetError extends Error {
 /** IPv4 range in the last octet, e.g. `10.0.0.1-50`, or a full-range dash form. */
 const IP_RANGE = /^\d{1,3}(?:\.\d{1,3}){3}\s*-\s*\d{1,3}/;
 
+/** A URI scheme prefix: `https://`, `ssh://`, `ldaps://`. */
+const SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/** A CIDR suffix proper: a slash followed by a prefix length and nothing else. */
+const CIDR_SUFFIX = /\/\d{1,3}$/;
+
+/**
+ * The host someone probably meant, for the error message only.
+ *
+ * Never used to accept the input: a target has to be named as one host, because
+ * `--i-own-this` is an ownership attestation and `https://mine.com@theirs.com/`
+ * resolves to `theirs.com`. Suggesting the answer while still refusing keeps the
+ * attestation explicit and the fix one copy-paste away.
+ */
+function suggestHost(raw: string): string | null {
+  try {
+    const url = new URL(SCHEME.test(raw) ? raw : `https://${raw}`);
+    const host = url.hostname.replace(/^\[|\]$/g, "");
+    return host || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Parse and validate a single target. Throws {@link TargetError} for anything
  * that is not a single host / host:port — the refusal is a security control, not
@@ -34,10 +58,39 @@ export function parseTarget(input: string, defaultPort: number): Target {
   const raw = input.trim();
   if (raw === "") throw new TargetError("empty target");
 
+  // A URL is still refused — a target is one named host, not something with a
+  // scheme, credentials and a path — but it must be refused for the right reason.
+  // This check has to come before the slash check below: `https://example.com`
+  // contains slashes, so it used to be reported as a CIDR block, which described
+  // a mistake the operator had not made.
+  if (SCHEME.test(raw)) {
+    const host = suggestHost(raw);
+    throw new TargetError(
+      `refusing URL "${raw}" — qProbe takes a host, not a URL${host ? `. Try: ${host}` : "."}`,
+    );
+  }
+
+  // Credentials name one host to a reader and connect to another
+  // (`https://mine.com@theirs.com`), which an ownership attestation cannot allow.
+  if (raw.includes("@")) {
+    const host = suggestHost(raw);
+    throw new TargetError(
+      `refusing target with credentials "${raw}" — name the host directly${host ? `. Try: ${host}` : "."}`,
+    );
+  }
+
   // Range / sweep / list markers are refused BEFORE any parsing.
   if (raw.includes("/")) {
+    // Distinguish an actual CIDR block from a path someone pasted: only a
+    // trailing prefix length is a range. Both are refused; only one is a sweep.
+    if (CIDR_SUFFIX.test(raw)) {
+      throw new TargetError(
+        `refusing CIDR block "${raw}" — qProbe probes one host at a time, not ranges.`,
+      );
+    }
+    const host = suggestHost(raw);
     throw new TargetError(
-      `refusing CIDR block "${raw}" — qProbe probes one host at a time, not ranges.`,
+      `refusing target with a path "${raw}" — qProbe probes a host, not a URL path${host ? `. Try: ${host}` : "."}`,
     );
   }
   if (raw.includes("*")) {

--- a/packages/qprobe/test/target.test.ts
+++ b/packages/qprobe/test/target.test.ts
@@ -22,3 +22,77 @@ test("rejects invalid ports", () => {
   assert.throws(() => parseTarget("h:99999", 443), TargetError);
   assert.throws(() => parseTarget("h:notaport", 443), TargetError);
 });
+
+/**
+ * A probe run failed with `refusing CIDR block "https://leonacosta.com"`. The
+ * slash check ran first, so every URL was reported as a range sweep — an error
+ * describing a mistake the operator had not made, and one that gave no hint
+ * about the fix. URLs are still refused (a target is one named host), but for
+ * the right reason and with the host to use.
+ */
+test("refuses a URL as a URL, not as a CIDR block, and names the host to use", () => {
+  assert.throws(
+    () => parseTarget("https://leonacosta.com", 443),
+    (err: Error) => {
+      assert.ok(err instanceof TargetError);
+      assert.match(err.message, /not a URL/);
+      assert.doesNotMatch(err.message, /CIDR/);
+      assert.match(err.message, /Try: leonacosta\.com/);
+      return true;
+    },
+  );
+});
+
+test("refuses a bare path as a path, while a real CIDR is still a CIDR", () => {
+  assert.throws(
+    () => parseTarget("example.com/blog", 443),
+    (err: Error) => {
+      assert.match(err.message, /path/);
+      assert.match(err.message, /Try: example\.com/);
+      return true;
+    },
+  );
+  // The security control this sits next to must not have been weakened.
+  assert.throws(
+    () => parseTarget("10.0.0.0/24", 443),
+    (err: Error) => {
+      assert.match(err.message, /CIDR block/);
+      return true;
+    },
+  );
+});
+
+/**
+ * `--i-own-this` is an ownership attestation, so a target that reads as one host
+ * and connects to another cannot be accepted. The suggestion deliberately names
+ * the host that WOULD have been probed, which is the useful thing to see.
+ */
+test("refuses credentials in a target and reveals the host they resolve to", () => {
+  assert.throws(
+    () => parseTarget("mine.com@theirs.com", 443),
+    (err: Error) => {
+      assert.match(err.message, /credentials/);
+      assert.match(err.message, /Try: theirs\.com/);
+      return true;
+    },
+  );
+});
+
+test("every scheme is refused, not just https", () => {
+  for (const target of [
+    "ssh://git.example.com",
+    "ldaps://dir.example.com:636",
+    "HTTP://example.com",
+  ]) {
+    assert.throws(() => parseTarget(target, 443), TargetError, target);
+  }
+});
+
+test("still accepts the plain forms the refusals sit around", () => {
+  assert.deepEqual(parseTarget("example.com", 443), { host: "example.com", port: 443 });
+  assert.deepEqual(parseTarget("api.example.com:8443", 443), {
+    host: "api.example.com",
+    port: 8443,
+  });
+  assert.deepEqual(parseTarget("[2001:db8::1]:443", 443), { host: "2001:db8::1", port: 443 });
+});


### PR DESCRIPTION
A probe run on a tracked repo failed with:

```
qprobe: refusing CIDR block "https://leonacosta.com" — qProbe probes one host at a time, not ranges.
```

The `raw.includes("/")` check ran before anything else, so **every URL was reported as a range sweep**. The message described a mistake the operator had not made and gave no hint about the fix. That cost a real run.

## What changes

URLs are still refused — a target is one named host — but for the right reason, and the message names the host to use:

```
refusing URL "https://example.com/health" — qProbe takes a host, not a URL. Try: example.com
```

- A slash is reported as a **CIDR block** only when it is actually a prefix length (`10.0.0.0/24`). A pasted path (`example.com/blog`) says *path* instead.
- A target carrying **credentials** (`mine.com@theirs.com`) is refused explicitly, and the suggestion names the host it would really have connected to. `--i-own-this` is an ownership attestation, so a target that reads as one host and resolves to another must not be accepted quietly — and if you are going to refuse it, showing which host it actually resolves to is the useful part.

## What does not change

The suggestion is for the message only. **Nothing is newly accepted.** The refusals that are security controls — CIDR blocks, IP ranges, wildcards, lists — still throw before any network I/O, and there is a test asserting the CIDR path still reports as CIDR so this cannot be loosened by accident.

I deliberately did **not** make qProbe accept URLs and normalise them internally. `parseTarget`'s stated stance is that the refusal is a security control rather than a convenience check, and silently resolving `https://mine.com@theirs.com/` to `theirs.com` would widen what `--i-own-this` attests to. The website generating the workflow normalises instead, where the resolved host is visible in the committed file.

SemVer: **patch**. Message and classification only.

## Verified

`npm run build`, `npm run lint`, `npm run format:check`, `npm test` across all 8 packages, 0 failures. qprobe's own suite goes 49 → 55 tests: URL-not-CIDR with the suggested host, path vs real CIDR, credentials, non-https schemes, and the plain forms still parsing.

Also documents in `--help` and the README that a target is a host, not a URL, since the interface never actually said so.

## Related

quantakrypto/website#118 strips the scheme when generating the probe workflow, so the bad target cannot be produced from the dashboard in the first place. This is the other half: the tool explaining itself correctly when someone types one by hand.