### PR TITLE
sarif: emit valid result taxa, so code scanning stops rejecting the whole file

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -11387,13 +11387,15 @@ function toSarif(result, opts) {
         ...f.cwe ? { cwe: f.cwe } : {},
         ...exposureProperties(exposureFor(f, opts?.hndl))
       },
-      ...f.cwe ? {
-        taxa: [
-          {
-            target: { id: f.cwe, toolComponent: { name: "CWE" } }
-          }
-        ]
-      } : {},
+      // A result's `taxa` holds reportingDescriptorReference objects directly:
+      // { id, index, guid, toolComponent }. It used to wrap them in `target`,
+      // which is the shape of a reportingDescriptorRelationship (what a RULE
+      // uses in `relationships`), not of a reference. GitHub's code-scanning
+      // upload validates against the real schema and rejected the whole file:
+      // "taxa[0] is not allowed to have the additional property target". Our own
+      // validator did not check inside taxa, so this shipped, and every consumer
+      // following the documented upload-sarif workflow got nothing.
+      ...f.cwe ? { taxa: [{ id: f.cwe, toolComponent: { name: "CWE" } }] } : {},
       locations: [
         {
           physicalLocation: {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -228,15 +228,15 @@ export function toSarif(result: ScanResult, opts?: ReportOptions): SarifLog {
         ...(f.cwe ? { cwe: f.cwe } : {}),
         ...exposureProperties(exposureFor(f, opts?.hndl)),
       },
-      ...(f.cwe
-        ? {
-            taxa: [
-              {
-                target: { id: f.cwe, toolComponent: { name: "CWE" } },
-              },
-            ],
-          }
-        : {}),
+      // A result's `taxa` holds reportingDescriptorReference objects directly:
+      // { id, index, guid, toolComponent }. It used to wrap them in `target`,
+      // which is the shape of a reportingDescriptorRelationship (what a RULE
+      // uses in `relationships`), not of a reference. GitHub's code-scanning
+      // upload validates against the real schema and rejected the whole file:
+      // "taxa[0] is not allowed to have the additional property target". Our own
+      // validator did not check inside taxa, so this shipped, and every consumer
+      // following the documented upload-sarif workflow got nothing.
+      ...(f.cwe ? { taxa: [{ id: f.cwe, toolComponent: { name: "CWE" } }] } : {}),
       locations: [
         {
           physicalLocation: {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -195,7 +195,13 @@ test("toSarif maps CWE into rule properties, result taxa, and run taxonomies", (
   assert.ok(run.tool.driver.rules[0].properties.tags.includes("CWE-327"));
 
   // results[].taxa references the CWE taxon.
-  assert.equal(run.results[0].taxa[0].target.id, "CWE-327");
+  // A result's taxa[] holds reportingDescriptorReference objects DIRECTLY.
+  // This assertion previously expected a `target` wrapper, which is the shape of
+  // a relationship rather than a reference — so the test agreed with the bug and
+  // GitHub rejected every SARIF we produced.
+  assert.equal(run.results[0].taxa[0].id, "CWE-327");
+  assert.equal(run.results[0].taxa[0].toolComponent.name, "CWE");
+  assert.equal(run.results[0].taxa[0].target, undefined);
   assert.equal(run.results[0].properties.cwe, "CWE-327");
 
   // run.taxonomies declares the CWE taxonomy component.

--- a/scripts/validate-sarif.mjs
+++ b/scripts/validate-sarif.mjs
@@ -107,6 +107,9 @@ export function validateSarif(doc) {
 }
 
 /** Validate a single SARIF result object. */
+/** The only properties SARIF allows on a reportingDescriptorReference. */
+const TAXA_REF_KEYS = new Set(["id", "index", "guid", "toolComponent"]);
+
 function validateResult(res, path, v) {
   if (!isObject(res)) {
     v.add(path, "result must be an object");
@@ -124,6 +127,35 @@ function validateResult(res, path, v) {
   if (!isObject(res.message) || typeof res.message.text !== "string") {
     v.add(`${path}.message.text`, "missing message.text string");
   }
+  // A result's taxa[] holds reportingDescriptorReference objects. The schema
+  // allows only id/index/guid/toolComponent, and GitHub's upload enforces it —
+  // it rejected the ENTIRE file over a stray `target` property that this
+  // validator was happy with, so every documented upload-sarif workflow was
+  // silently getting nothing. Check inside taxa, not just that it is an array.
+  if (res.taxa !== undefined) {
+    if (!Array.isArray(res.taxa)) {
+      v.add(`${path}.taxa`, "taxa must be an array of reportingDescriptorReference");
+    } else {
+      res.taxa.forEach((ref, ti) => {
+        const at = `${path}.taxa[${ti}]`;
+        if (!isObject(ref)) {
+          v.add(at, "taxa entry must be an object");
+          return;
+        }
+        const extra = Object.keys(ref).filter((k) => !TAXA_REF_KEYS.has(k));
+        if (extra.length > 0) {
+          v.add(
+            at,
+            `unknown propert${extra.length === 1 ? "y" : "ies"} ${extra.join(", ")} (allowed: ${[...TAXA_REF_KEYS].join(", ")})`,
+          );
+        }
+        if (ref.id === undefined && ref.index === undefined && ref.guid === undefined) {
+          v.add(at, "reference must carry at least one of id, index, guid");
+        }
+      });
+    }
+  }
+
   if (!Array.isArray(res.locations) || res.locations.length === 0) {
     v.add(`${path}.locations`, "missing or empty locations[]");
   } else {


### PR DESCRIPTION
Found by pointing our own scanner at our own repository for the first time (quantakrypto/website#123). The first run failed — and not on findings.

## The bug

A result's `taxa[]` holds `reportingDescriptorReference` objects **directly**: `{ id, index, guid, toolComponent }`. We wrapped them in `target`, which is the shape of a `reportingDescriptorRelationship` — what a *rule* uses in `relationships`, not what a *result* uses in `taxa`.

GitHub validates the upload against the real schema and rejects **the entire file**:

```
Unable to upload "quantakrypto.sarif.json" as it is not valid SARIF:
- instance.runs[0].results[0].taxa[0] is not allowed to have the additional property "target"
```

So every consumer following the workflow we document — action writes SARIF, `upload-sarif` publishes it — has been getting **nothing** in their Security tab. The action README, both example workflows, and the docs all describe exactly that path.

## Why it shipped, and why that is the more important half

Two safeguards should have caught it and both agreed with the bug:

- **`scripts/validate-sarif.mjs` checked that `taxa` was an array and never looked inside it.** A structurally invalid file passed our CI and failed GitHub's. It now rejects any property outside the four the schema allows and requires at least one of `id`/`index`/`guid`. I verified it flags precisely the shape we were emitting before accepting the fix.
- **The core unit test asserted `taxa[0].target.id`.** The test encoded the bug, so fixing the emitter alone would have turned the suite red and read like a regression. Corrected, with an assertion that `target` is now absent.

## Verified

`npm run build`, `npm run lint`, `npm run format:check`, `npm test` across all 8 packages, 0 failures. `dist/index.js` rebundled. Real output re-checked: 152 results carry `taxa`, all of the form `{"id":"CWE-327","toolComponent":{"name":"CWE"}}`.