### PR TITLE
action: expose --ignore/--include, and document what the SARIF upload needs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,21 @@ inputs:
     description: "Directory (or file) to scan, relative to the repository root."
     required: false
     default: "."
+  ignore:
+    description: >-
+      Extra paths to exclude, comma- or newline-separated (repeatable `--ignore`
+      on the CLI). Useful for content, fixtures or docs that DESCRIBE cryptography
+      without using it: those match the detectors and become findings you never
+      wanted scanned. A baseline is the wrong tool for that, because it records
+      them as known debt rather than as not-code.
+    required: false
+    default: ""
+  include:
+    description: >-
+      Restrict the scan to paths matching these patterns, comma- or
+      newline-separated. When empty, everything not excluded is scanned.
+    required: false
+    default: ""
   severity-threshold:
     description: >-
       Minimum severity that counts as a failure: critical, high, medium, low,

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   security-events: write   # required to upload SARIF to code scanning
+  actions: read            # also required by upload-sarif (see note below)
   pull-requests: write     # only if you enable comment-pr
 
 jobs:
@@ -42,13 +43,30 @@ jobs:
           comment-pr: "true"
           github-token: ${{ github.token }}
 
-      # Upload to GitHub code scanning (Security tab). Runs even if the scan failed.
+      # Upload to GitHub code scanning (Security tab). Runs even if the scan
+      # failed. Needs actions: read above, and Advanced Security on a private
+      # repo — see the note below.
       - name: Upload SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.quantakrypto.outputs.sarif-file }}
 ```
+
+> **The SARIF upload needs two things beyond this snippet.**
+>
+> `permissions:` must include **`actions: read`** as well as `security-events:
+> write`. Without it the upload validates your file, adds fingerprints, and then
+> fails with `Resource not accessible by integration`, which reads like a problem
+> with the SARIF rather than a missing scope.
+>
+> And code scanning itself requires **GitHub Advanced Security on private
+> repositories**. It is free and always on for public repos; on a private repo
+> without it the upload refuses with `Advanced Security must be enabled for this
+> repository`. If you do not have it, drop the upload step: the scan still writes
+> a job summary and annotates the diff, which is where most of the value is. Add
+> `continue-on-error: true` if you would rather leave the step in place so it
+> starts working the day it is enabled.
 
 A ready-to-copy workflow lives at
 [`examples/quantum-readiness.yml`](examples/quantum-readiness.yml).

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -54,6 +54,21 @@ inputs:
     description: "Directory (or file) to scan, relative to the repository root."
     required: false
     default: "."
+  ignore:
+    description: >-
+      Extra paths to exclude, comma- or newline-separated (repeatable `--ignore`
+      on the CLI). Useful for content, fixtures or docs that DESCRIBE cryptography
+      without using it: those match the detectors and become findings you never
+      wanted scanned. A baseline is the wrong tool for that, because it records
+      them as known debt rather than as not-code.
+    required: false
+    default: ""
+  include:
+    description: >-
+      Restrict the scan to paths matching these patterns, comma- or
+      newline-separated. When empty, everything not excluded is scanned.
+    required: false
+    default: ""
   severity-threshold:
     description: >-
       Minimum severity that counts as a failure: critical, high, medium, low,

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -16692,6 +16692,8 @@ function readInputs(env = process.env) {
     conformanceImpl,
     conformanceParam: getInput("conformance-param", env) || "ml-kem-768",
     path: getInput("path", env) || ".",
+    ignore: splitPatterns(getInput("ignore", env)),
+    include: splitPatterns(getInput("include", env)),
     severityThreshold,
     failOnFindings: getBooleanInput("fail-on-findings", true, env),
     format,
@@ -17010,6 +17012,9 @@ async function report(dispatch, result) {
     );
   }
 }
+function splitPatterns(raw) {
+  return raw.split(/[\n,]+/).map((p) => p.trim()).filter(Boolean);
+}
 async function run(env = process.env) {
   const inputs = readInputs(env);
   const dispatch = readDispatchContext(env);
@@ -17063,7 +17068,9 @@ ${result2.summary}
   const { result } = await runQscan({
     path: scanRoot,
     format: inputs.format,
-    severityThreshold: inputs.severityThreshold
+    severityThreshold: inputs.severityThreshold,
+    ...inputs.ignore.length > 0 ? { ignore: inputs.ignore } : {},
+    ...inputs.include.length > 0 ? { include: inputs.include } : {}
   });
   const baseline = inputs.baseline ? await loadBaselineSet(inputs.baseline, env) : { version: 1, fingerprints: [] };
   const { newFindings } = applyBaseline(result.findings, baseline);
@@ -17155,5 +17162,6 @@ export {
   meetsThreshold,
   readInputs,
   run,
-  shouldFail
+  shouldFail,
+  splitPatterns
 };

--- a/packages/action/examples/quantum-readiness.yml
+++ b/packages/action/examples/quantum-readiness.yml
@@ -14,7 +14,9 @@ on:
 
 permissions:
   contents: read
-  security-events: write # upload SARIF to the Security tab
+  security-events: write
+  # Required by upload-sarif to resolve the run it attaches results to.
+  actions: read # upload SARIF to the Security tab
   pull-requests: write # comment on pull requests
 
 jobs:
@@ -39,7 +41,12 @@ jobs:
           comment-pr: "true"
           github-token: ${{ github.token }}
 
-      - name: Upload SARIF to code scanning
+      # Code scanning needs GitHub Advanced Security on a PRIVATE repository
+      # (it is free on public ones). Without it this step fails with "Advanced
+      # Security must be enabled". continue-on-error keeps the scan useful
+      # meanwhile: the job summary and diff annotations are written regardless.
+      - name: Upload SARIF
+        continue-on-error: true to code scanning
         if: always() # upload even when the scan failed the job
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/packages/action/src/main.ts
+++ b/packages/action/src/main.ts
@@ -81,6 +81,10 @@ interface ActionInputs {
   /** Parameter set for "conformance", e.g. ml-kem-768. */
   conformanceParam: string;
   path: string;
+  /** Extra exclude patterns. Empty means "just the built-in ignores". */
+  ignore: string[];
+  /** Restrict the walk to these patterns. Empty means "everything". */
+  include: string[];
   severityThreshold: Severity;
   failOnFindings: boolean;
   format: "sarif" | "json";
@@ -156,6 +160,8 @@ export function readInputs(env: NodeJS.ProcessEnv = process.env): ActionInputs {
     conformanceImpl,
     conformanceParam: getInput("conformance-param", env) || "ml-kem-768",
     path: getInput("path", env) || ".",
+    ignore: splitPatterns(getInput("ignore", env)),
+    include: splitPatterns(getInput("include", env)),
     severityThreshold,
     failOnFindings: getBooleanInput("fail-on-findings", true, env),
     format,
@@ -689,6 +695,19 @@ async function report(
   }
 }
 
+/**
+ * Split a comma- or newline-separated pattern list.
+ *
+ * Both separators, because a YAML block scalar is the natural way to write more
+ * than two of these and a single line is the natural way to write one.
+ */
+export function splitPatterns(raw: string): string[] {
+  return raw
+    .split(/[\n,]+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
 /** The full action run, parameterised on `env` for testability. */
 export async function run(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   const inputs = readInputs(env);
@@ -781,6 +800,8 @@ export async function run(env: NodeJS.ProcessEnv = process.env): Promise<void> {
     path: scanRoot,
     format: inputs.format,
     severityThreshold: inputs.severityThreshold,
+    ...(inputs.ignore.length > 0 ? { ignore: inputs.ignore } : {}),
+    ...(inputs.include.length > 0 ? { include: inputs.include } : {}),
   });
 
   // Apply the shared baseline so only NEW quantum-vulnerable crypto can fail.

--- a/packages/action/test/checks.test.ts
+++ b/packages/action/test/checks.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { assertCheckConfig, isCheckId, normalizeProbeTarget, parseChecks } from "../src/checks.js";
-import { dispatchAskedFor } from "../src/main.js";
+import { dispatchAskedFor, splitPatterns } from "../src/main.js";
 
 /**
  * The `checks` input is what collapses three workflow files into one. Its
@@ -113,4 +113,30 @@ test("an unrecognised or absent dispatch reports nothing", () => {
     assert.ok(!dispatchAskedFor("", check));
     assert.ok(!dispatchAskedFor("some-other-event", check));
   }
+});
+
+/**
+ * The CLI has --ignore and --include; the action had neither, so a repository
+ * with content, fixtures or docs that DESCRIBE cryptography had no way to
+ * exclude them. Our own website proved it: two of its four high findings were
+ * marketing copy about RSA and HSMs. A baseline is the wrong tool for that — it
+ * records them as known debt rather than as not-code.
+ */
+test("pattern lists accept commas, newlines, and the mix of both YAML encourages", () => {
+  assert.deepEqual(splitPatterns("src/content"), ["src/content"]);
+  assert.deepEqual(splitPatterns("a,b"), ["a", "b"]);
+  assert.deepEqual(splitPatterns("a\nb"), ["a", "b"]);
+  assert.deepEqual(splitPatterns("a, b\nc"), ["a", "b", "c"]);
+});
+
+test("pattern lists tolerate the whitespace a block scalar leaves behind", () => {
+  assert.deepEqual(splitPatterns("  a  ,\n  b  \n"), ["a", "b"]);
+  assert.deepEqual(splitPatterns("a,,b"), ["a", "b"]);
+});
+
+test("an unset pattern list is empty, not a pattern matching everything", () => {
+  // [] must mean "no restriction"; [""] would restrict the walk to nothing.
+  assert.deepEqual(splitPatterns(""), []);
+  assert.deepEqual(splitPatterns("   "), []);
+  assert.deepEqual(splitPatterns(",\n,"), []);
 });


### PR DESCRIPTION
Two things our own dogfooding surfaced (quantakrypto/website#123).

## `--ignore` / `--include` were unreachable from the action

The CLI has both. The action had neither, so anyone using the action — which is the path our dashboard generates and our docs recommend — could not exclude a path.

Our own website is the proof. Two of its four high findings were **marketing copy** describing RSA and HSMs, not code:

```
without --ignore: 62 findings, 4 high+, readiness 19/100
with    --ignore: 19 findings, 2 high+, readiness 42/100
remaining high+:  package-lock.json, package-lock.json
```

Excluding the content datasets — which every other `qscan` invocation in that repo already did — leaves exactly the two genuine dependency findings. Our real posture was 42/100 with two real issues, not 19/100 with four.

Without this input the only workaround is a baseline, and that is the wrong tool. A baseline records a finding as **known debt to be fixed later**. A blog post that mentions RSA is not debt. It is not code.

Patterns split on commas or newlines, because a YAML block scalar is the natural way to write several and a single line is the natural way to write one. An unset list stays `[]` rather than becoming `[""]`, which would restrict the walk to nothing instead of leaving it unrestricted — there is a test for that specifically.

## The SARIF upload's two undocumented requirements

`upload-sarif` needs **`actions: read`** as well as `security-events: write`. Without it the upload validates the file, adds fingerprints, and *then* fails with `Resource not accessible by integration`, which reads like a problem with the SARIF rather than a missing scope. `examples/quantum-readiness.yml` already had it; the README quick start did not — which is exactly how I hit it, by writing our dogfood workflow from scratch instead of from our own example.

And code scanning requires **GitHub Advanced Security on private repositories** (free and always on for public ones). Without it the upload refuses outright and no workflow change fixes it. The docs now say so and give the two honest options: drop the step, or keep it with `continue-on-error` so it starts working the day it is enabled. The scan is useful either way, since the job summary and diff annotations are written regardless.

## Verified

`build`, `lint`, `format:check`, `test` across all 8 packages, 0 failures. 98 action tests. `check-action-yml-sync` passes at 21 inputs. `dist/index.js` rebundled. The filtering numbers above are from a real run against quantakrypto/website, not a fixture.