### PR TITLE
release: 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-08
+
+Minor: three additive features and two user-facing bug fixes. Nothing existing
+changes shape, and no exit code moves.
+
+### Fixed - the SARIF we produced was rejected by GitHub code scanning, in full
+
+A result's `taxa[]` holds reportingDescriptorReference objects directly. We
+wrapped them in `target`, which is relationship shape, and GitHub rejected the
+entire file: "taxa[0] is not allowed to have the additional property target".
+Every consumer following the workflow we document - action writes SARIF,
+upload-sarif publishes it - had been getting nothing in their Security tab.
+
+Two safeguards agreed with the bug and are fixed with it: validate-sarif checked
+that taxa was an array without looking inside it, and the unit test asserted the
+broken shape. Found by running our own scanner against our own repository for
+the first time.
+
+### Added - `ignore` and `include` inputs on the action
+
+The CLI had both; the action had neither, so anything reachable only through the
+action could not exclude a path. Content, fixtures and docs that DESCRIBE
+cryptography match the detectors and become findings nobody wanted scanned. A
+baseline was the only workaround and it is the wrong tool: it records a finding
+as known debt, and a blog post mentioning RSA is not debt.
+
+
 ### Added - action: one workflow runs any combination of scan, conformance and probe
 
 The action takes a `checks` input (any subset of `scan`, `conformance`, `probe`)

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -26,7 +26,7 @@ var VERSION;
 var init_version = __esm({
   "../core/dist/version.js"() {
     "use strict";
-    VERSION = "0.9.0";
+    VERSION = "0.10.0";
   }
 });
 

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/action",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "quantakrypto Action — fail CI when new quantum-vulnerable cryptography lands. GitHub Action wrapping qScan.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -25,10 +25,10 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.9.0",
-    "@quantakrypto/qprobe": "0.9.0",
-    "@quantakrypto/qscan": "0.9.0",
-    "@quantakrypto/sieve": "0.9.0"
+    "@quantakrypto/core": "0.10.0",
+    "@quantakrypto/qprobe": "0.10.0",
+    "@quantakrypto/qscan": "0.10.0",
+    "@quantakrypto/sieve": "0.10.0"
   },
   "devDependencies": {
     "esbuild": "0.28.1"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/agent",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "BYOK LLM client for qScan triage and remediation. Native fetch, zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.9.0"
+    "@quantakrypto/core": "0.10.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared post-quantum readiness library: crypto detectors, vulnerable-dependency database, inventory + SARIF reporting. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -3,4 +3,4 @@
  * the scan orchestrator can import it without creating a cycle through index.ts.
  * Keep in sync with packages/core/package.json.
  */
-export const VERSION = "0.9.0";
+export const VERSION = "0.10.0";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "mcpName": "io.github.quantakrypto/pqc-tools",
   "description": "quantakrypto MCP — post-quantum readiness for AI coding agents via the Model Context Protocol. Zero runtime dependencies (stdio JSON-RPC implemented in-house).",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.9.0",
-    "@quantakrypto/qprobe": "0.9.0"
+    "@quantakrypto/core": "0.10.0",
+    "@quantakrypto/qprobe": "0.10.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/package.json
+++ b/packages/qprobe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qprobe",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "qProbe — actively inspect live TLS/SSH endpoints you OWN for post-quantum readiness (hybrid KEX, classical certs). Gated behind an ownership attestation. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.9.0"
+    "@quantakrypto/core": "0.10.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qscan/package.json
+++ b/packages/qscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qscan",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "qScan — find quantum-vulnerable cryptography in any codebase (CLI). Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,8 +37,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/agent": "0.9.0",
-    "@quantakrypto/core": "0.9.0"
+    "@quantakrypto/agent": "0.10.0",
+    "@quantakrypto/core": "0.10.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/sieve/package.json
+++ b/packages/sieve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/sieve",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Sieve — conformance battery for ML-KEM / ML-DSA implementations. Drives any implementation over a simple stdin/stdout JSON protocol. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",


### PR DESCRIPTION
Version bump and changelog for the five substantive commits since `v0.9.0`. **Merging this does not publish** — publishing happens on a GitHub Release, which is a separate deliberate step.

## What ships

**Fixed — our SARIF was rejected by code scanning, in full** (#54). A result's `taxa[]` holds reporting-descriptor references directly; we wrapped them in `target`, which is relationship shape, so GitHub refused the entire file. Every consumer following the workflow we document had been getting nothing in their Security tab. Two safeguards agreed with the bug and are fixed with it: the validator never looked inside `taxa`, and the unit test asserted the broken shape.

**Fixed — qProbe refuses a URL as a URL** (#51), not as a CIDR block, and names the host to use.

**Added — one action runs any combination of scan/conformance/probe** (#52), owning the result reporting that used to live as `jq` inside every user's repository.

**Added — `ignore` / `include` inputs** (#55). Without them, content that *describes* cryptography could only be suppressed with a baseline, which records it as known debt rather than as not-code.

**Added — Sieve reports `ERROR` when the implementation could not be run** (#50), instead of inventing ~35 conformance defects against code that never executed.

Version bump is **minor**: all additive, nothing reshaped, no exit code moved. Also bumps the hand-maintained `VERSION` constant in core — caught by its own test, which is worth having, since a release whose `--version` lies is the kind of thing nobody notices until a bug report cites the wrong number.

## Before publishing — one side effect worth a decision

`release.yml` **force-moves the `v1` tag** to the released commit. Every scan workflow the platform has ever generated pins `@v1`, so all of them would start running the unified action.

I traced it and believe it is safe: under a platform dispatch the new action posts the result itself, then the workflow's own `jq` step posts too and gets a 403 because the callback token is single-use. First write wins, `curl -sS` exits 0, the job stays green. The old scan template sets no baseline, so the content is equivalent. Conformance and probe workflows use `npx` rather than the action and are untouched.

So: benign, but it is a behaviour change for every existing user with no commit in their repository, and it deserves to be a decision rather than a side effect nobody mentioned.

## Verified

`build`, `lint`, `format:check`, `test` across all 8 packages, 0 failures. `dist/index.js` rebundled at the new version.