### PR TITLE
docs: fix the action documentation, and check the examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,10 @@ jobs:
         run: node scripts/check-offline-boundary.mjs
       - name: action.yml pair in sync (root Marketplace copy vs packages/action)
         run: node scripts/check-action-yml-sync.mjs
+      # GitHub never parses packages/action/examples, so a broken one ships to
+      # every reader who copies it. One did.
+      - name: Example workflows are well-formed and pinned to a moving major
+        run: node scripts/check-example-workflows.mjs
       - name: REUSE lint (SPDX / licensing) — advisory
         continue-on-error: true
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,11 +124,14 @@ jobs:
       # stale, pre-security-fix bundle (2026-07-15 supply-chain audit). Runs only on
       # a real published Release, not a manual dry-run/publish dispatch.
       #
-      # This moved v1 only, hardcoded. When v2 was cut, the 0.10.0 release left it
-      # a commit behind v1 - and v2 is the tag the platform's generated workflows
-      # pin, so the tag most consumers actually use was the stale one. Discovering
-      # the tags instead of listing them means a future v3 needs no edit here,
-      # which is exactly the failure this had.
+      # This moved v1 only, hardcoded. A short-lived v2 was cut for the `checks`
+      # input and the 0.10.0 release left it a commit behind v1 - while v2 was
+      # the tag the platform's generated workflows pinned, so the tag consumers
+      # actually used was the stale one. v2 has since been deleted (`checks`
+      # defaults to `scan`, so it was never a breaking change and never earned a
+      # new major), leaving v1 as the only moving tag. Discovering the tags
+      # rather than listing them is what keeps a real future v3 from repeating
+      # this, and costs nothing while v1 is the only one.
       - name: Move the major-version Action tags to this release
         if: ${{ github.event_name == 'release' }}
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ There are two consumption surfaces, versioned on two different schemes:
 
 - **npm packages** (`@quantakrypto/core`, `@quantakrypto/qscan`, `@quantakrypto/mcp`,
   `@quantakrypto/sieve`, `@quantakrypto/qprobe`, `@quantakrypto/agent`) are pre-1.0,
-  currently `0.9.x`. Only the latest `main` is supported while the API stabilises,
+  currently `0.10.x`. Only the latest `main` is supported while the API stabilises,
   and we make no backward-compatibility promises before 1.0. Versioned support
   windows for the packages will be defined at the 1.0 release. The full policy is
   in [`docs/VERSIONING.md`](docs/VERSIONING.md).

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,9 @@ inputs:
     description: >-
       Which checks to run: any comma-separated subset of "scan" (qScan static
       analysis), "conformance" (Sieve, FIPS 203/204/205) and "probe" (qProbe,
-      live TLS/SSH). Defaults to "scan", which is exactly what v1 did, so an
-      existing workflow keeps working unchanged.
+      live TLS/SSH). Defaults to "scan", which is what this action did before
+      this input existed, so an existing workflow keeps working unchanged. That
+      is why adding it did not move the @v1 tag: it is not a breaking change.
     required: false
     default: "scan"
   probe-target:

--- a/docs/SUPPLY-CHAIN.md
+++ b/docs/SUPPLY-CHAIN.md
@@ -10,7 +10,7 @@ buys several assurance checks for free; the gaps are process, not dependencies.
 
 ## 1. Targets vs. current status
 
-> **Status as of 0.9.0 (prepared; 0.8.0 published):** provenance is **live**, the
+> **Status as of 0.10.0 (published):** provenance is **live**, the
 > Scorecard workflow is **wired**, `reuse lint` runs in CI (advisory), per-package
 > `LICENSE` files ship in the tarballs, and the `v1` Action tag is **auto-moved**
 > to each released commit on publish (see §3). The remaining gap is a repo
@@ -62,9 +62,12 @@ committed and guarded by a "dist is fresh" CI gate (`ci.yml`) + a pre-publish ga
 - **The `v1` Action tag auto-moves.** Since 0.4.3, `release.yml` force-moves `v1`
   to the released commit after a successful publish, so
   `uses: quantakrypto/pqc-tools/packages/action@v1` always runs the latest
-  released bundle.
+  released bundle. Since 0.10.0 the step *discovers* the `vN` tags rather than
+  naming `v1`, so a future major cannot be left behind on a stale bundle. `v1`
+  is the only one today: the action has had no breaking change, and a moving
+  major tag is the wrong place to record anything else.
 - **Immutable semver tags exist.** Every release since v0.4.3 cuts a `vX.Y.Z` tag
-  (v0.4.3 … v0.8.0), so consumers and provenance verifiers can pin a non-mutable
+  (v0.4.3 … v0.10.0), so consumers and provenance verifiers can pin a non-mutable
   ref. The residual refinement is publishing *from* the tag ref rather than `main`.
 
 ## 4. SPDX / REUSE licensing

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -6,8 +6,14 @@ A zero-dependency GitHub Action that runs [qScan](../qscan) over your repository
 writes a [SARIF](https://sarifweb.azurewebsites.net/) report you can upload to
 GitHub code scanning, annotates every finding inline in the diff, and (optionally)
 comments a summary on the pull request. With a **baseline**, only *new*
-quantum-vulnerable crypto fails the build — so you can adopt it on a legacy
+quantum-vulnerable crypto fails the build, so you can adopt it on a legacy
 codebase without drowning in pre-existing findings.
+
+It also runs the other two checks, selected with [`checks`](#running-more-than-a-scan):
+**conformance** ([Sieve](../sieve), FIPS 203/204/205 against your own
+implementation) and **probe** ([qProbe](../qprobe), a live TLS/SSH handshake
+against an endpoint you own). `checks` defaults to `scan`, so a workflow that
+never sets it behaves exactly as it always has.
 
 ## Quick start
 
@@ -48,7 +54,7 @@ jobs:
       # repo — see the note below.
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.quantakrypto.outputs.sarif-file }}
 ```
@@ -82,6 +88,8 @@ A ready-to-copy workflow lives at
 | `conformance-param` | `ml-kem-768` | Parameter set for the conformance battery. |
 | `mode` | `scan` | `scan` writes a report and gates the build; `comment-plan` posts a deterministic PQC migration plan as a PR comment and **never** fails the build. |
 | `path` | `.` | Directory (or file) to scan, relative to the repo root. |
+| `ignore` | | Extra paths to exclude, comma- or newline-separated (the CLI's repeatable `--ignore`). Use it for content, fixtures or docs that *describe* cryptography without using it: they match the detectors and become findings you never wanted. A baseline is the wrong tool there, because it files them as known debt rather than as not-code. |
+| `include` | | Restrict the scan to paths matching these patterns, comma- or newline-separated. Empty scans everything not excluded. |
 | `severity-threshold` | `high` | Minimum severity that fails the build: `critical`, `high`, `medium`, `low`, `info`. Findings below this never fail. |
 | `fail-on-findings` | `true` | When `true`, exit non-zero if any finding at/above the threshold remains. Set `false` to report only. |
 | `format` | `sarif` | Report format written to `output`: `sarif` or `json`. |
@@ -102,6 +110,70 @@ A ready-to-copy workflow lives at
 | `findings-count` | Number of findings at/above the threshold, after baseline. |
 | `sarif-file` | Path of the report file that was written. |
 | `readiness-score` | Post-quantum readiness score, 0 (worst) – 100 (no classical asymmetric crypto found). |
+
+## Running more than a scan
+
+`checks` takes any comma-separated subset of `scan`, `conformance` and `probe`,
+so one step covers all seven combinations.
+
+The checks are **independent**, which is worth being precise about: each writes
+its own section of the job summary, and one failing does not take the others
+down with it. The SARIF report, the outputs, and the [exit
+behavior](#exit-behavior) below all come from `scan` alone. Conformance and probe
+report their verdicts to the job summary (and, on a platform-triggered run, to
+quantakrypto); a failing conformance battery or a weak endpoint does not fail
+the job. A *misconfiguration* still does, as it does for the scan: a missing
+`i-own-this`, an unknown check id, an unusable `conformance-impl`.
+
+```yaml
+      - uses: quantakrypto/pqc-tools/packages/action@v1
+        with:
+          checks: "scan,conformance,probe"
+
+          # conformance (Sieve) — drives YOUR implementation over the stdin/stdout
+          # JSON protocol, so the command must exist in this repository.
+          conformance-impl: "node ./pqc/impl.js"
+          conformance-param: "ml-kem-768"
+
+          # probe (qProbe) — a benign, unauthenticated handshake against one
+          # endpoint. `i-own-this` is your attestation and is REQUIRED; the action
+          # will not make it for you, and qProbe refuses to run without it.
+          probe-target: "api.example.com"
+          i-own-this: "true"
+```
+
+Three things are worth knowing before you enable them:
+
+- **`conformance` runs a command from your repository.** That is the whole point
+  of a conformance harness, but it means the step executes repository code. On a
+  `pull_request` from a fork, that code is the contributor's. Gate it
+  accordingly, or run conformance only on `push`.
+- **`i-own-this` is a legal statement, not a flag.** Active probing of endpoints
+  you are not authorised to test may be unlawful. It lives in the committed
+  workflow so it is attributable in `git blame`.
+- **A conformance run that cannot start is a failure, not a clean sheet.** If
+  `conformance-impl` does not resolve to a runnable command, every check in the
+  battery fails identically. The action reports that as one "the harness never
+  ran" finding rather than as hundreds of cryptographic defects.
+
+## Reporting to the quantakrypto platform
+
+When a repository is connected at [quantakrypto.com](https://quantakrypto.com),
+the platform triggers this action with a `repository_dispatch` and the action
+posts the result back. That is the **only** case in which it makes an outbound
+request, and it is constrained on purpose:
+
+- it runs only for a `repository_dispatch` event, never on `push`, `pull_request`
+  or `workflow_dispatch`;
+- the callback URL must be `https://quantakrypto.com`. Any other origin is
+  refused, so a forged dispatch cannot redirect the callback (which carries a
+  one-time token) to a host of the attacker's choosing;
+- redirects are refused rather than followed, and the request times out;
+- the token is registered as a secret with the runner, so it is masked in logs.
+
+Nothing about your source leaves CI: the payload is the readiness score, the
+finding list, and a one-line summary. You do not write any of this yourself.
+Committing the generated workflow is the whole integration.
 
 ## Comment-only migration plan (`mode: comment-plan`)
 
@@ -209,6 +281,18 @@ Typical adoption flow:
   [`@quantakrypto/core`](../core), so the Action and the `qscan` CLI produce identical
   findings, reports, and baseline semantics. This module is just the
   GitHub-runner glue (inputs, outputs, annotations, PR comment, exit policy).
+  The same holds for the other two checks: `conformance` calls
+  [`@quantakrypto/sieve`](../sieve) and `probe` calls
+  [`@quantakrypto/qprobe`](../qprobe), including qProbe's own target parser, so
+  the ownership rule that gates the CLI is the one that gates the Action rather
+  than a second copy of it here.
+- **One place decides what a result means** — the payload the platform receives
+  is built in [`src/platform.ts`](src/platform.ts), not in the user's workflow.
+  It used to be `jq` inside every repository that installed us, which meant a bug
+  in it could never be fixed for anyone who had already committed it. A
+  conformance run whose implementation could not start was reported as ~35
+  high-severity crypto defects; correcting the `jq` changed only what *new*
+  repositories would generate. Here, it is fixed for everyone on their next run.
 - **Output-injection hardened** — a finding's `file`/`message`/`ruleId` come from
   the *scanned* repo, so in a fork PR they are attacker-controlled. Two sinks the
   Action writes with a token are escaped accordingly:

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -13,8 +13,9 @@ inputs:
     description: >-
       Which checks to run: any comma-separated subset of "scan" (qScan static
       analysis), "conformance" (Sieve, FIPS 203/204/205) and "probe" (qProbe,
-      live TLS/SSH). Defaults to "scan", which is exactly what v1 did, so an
-      existing workflow keeps working unchanged.
+      live TLS/SSH). Defaults to "scan", which is what this action did before
+      this input existed, so an existing workflow keeps working unchanged. That
+      is why adding it did not move the @v1 tag: it is not a breaking change.
     required: false
     default: "scan"
   probe-target:

--- a/packages/action/examples/infra-readiness.yml
+++ b/packages/action/examples/infra-readiness.yml
@@ -14,6 +14,12 @@
 #      CBOM with a fresh scan CBOM into one combined "code + infrastructure + wire"
 #      CycloneDX bill of materials (`qscan --cbom --merge`) and uploads it.
 #
+# This example keeps qProbe on the CLI ON PURPOSE: it probes a LIST of hosts from a
+# committed manifest and merges the result into a combined CBOM, and the Action's
+# probe check does neither — it takes one `probe-target` and reports a verdict. If
+# a single endpoint and a verdict is all you need, drop the second job entirely and
+# add `checks: "scan,probe"` with `probe-target` and `i-own-this` to the first.
+#
 # qProbe only ever performs a benign, unauthenticated handshake and never modifies
 # an endpoint; it refuses to run without the ownership manifest. Commit the manifest
 # at `.quantakrypto/owned-hosts.txt` (one host per line, `#` comments allowed) — it
@@ -31,6 +37,7 @@ on:
 permissions:
   contents: read
   security-events: write # upload SARIF to the Security tab
+  actions: read # also required by upload-sarif, and its absence reads as a bad SARIF
 
 jobs:
   # 1) Scan code + infrastructure-as-code on every change.
@@ -41,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Scan for quantum-vulnerable crypto (code + infrastructure)
+        id: qscan
         uses: quantakrypto/pqc-tools/packages/action@v1
         with:
           path: "."
@@ -49,6 +57,16 @@ jobs:
           format: "sarif"
           output: "quantakrypto.sarif.json"
           github-token: ${{ github.token }}
+
+      # Code scanning needs GitHub Advanced Security on a PRIVATE repository (it
+      # is free on public ones). continue-on-error keeps the job useful without
+      # it: the summary and the diff annotations are written either way.
+      - name: Upload SARIF to code scanning
+        continue-on-error: true
+        if: always() # upload even when the scan failed the job
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.qscan.outputs.sarif-file }}
 
       - name: Generate code + config CBOM
         if: always()

--- a/packages/action/examples/quantum-readiness.yml
+++ b/packages/action/examples/quantum-readiness.yml
@@ -45,10 +45,10 @@ jobs:
       # (it is free on public ones). Without it this step fails with "Advanced
       # Security must be enabled". continue-on-error keeps the scan useful
       # meanwhile: the job summary and diff annotations are written regardless.
-      - name: Upload SARIF
-        continue-on-error: true to code scanning
+      - name: Upload SARIF to code scanning
+        continue-on-error: true
         if: always() # upload even when the scan failed the job
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.quantakrypto.outputs.sarif-file }}
 

--- a/scripts/check-action-yml-sync.mjs
+++ b/scripts/check-action-yml-sync.mjs
@@ -3,7 +3,7 @@
  * The action ships two metadata files and nothing was checking they agree.
  *
  *   action.yml                 repository root, so the Marketplace can list it
- *   packages/action/action.yml the canonical path, `uses: …/packages/action@v2`
+ *   packages/action/action.yml the canonical path, `uses: …/packages/action@v1`
  *
  * They must declare the SAME inputs and outputs, because both entrypoints run
  * the same bundle. A drifting pair is silent and nasty: an input added to one

--- a/scripts/check-example-workflows.mjs
+++ b/scripts/check-example-workflows.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * The example workflows are copy-paste product, and nothing was checking them.
+ *
+ * `packages/action/examples/*.yml` is what the READMEs tell people to drop into
+ * `.github/workflows/`. Unlike our own workflows, GitHub never parses these, so a
+ * broken one ships silently. One did: an edit merged a step name into the key
+ * below it, leaving `continue-on-error: true to code scanning`. That is *valid
+ * YAML* — the value is just a string — so neither prettier nor any YAML parser
+ * would have caught it. Only a workflow-aware check does.
+ *
+ * This is deliberately narrow rather than a workflow schema:
+ *
+ *   1. keys whose value must be a boolean actually hold one;
+ *   2. `uses:` is a single well-formed ref;
+ *   3. a `uses:` of OUR action pins a bare moving major (`@vN`), never a semver
+ *      tag or a branch. An example pinning `@v1.2.3` or `@main` would freeze or
+ *      float every repository that copied it.
+ *
+ * Hand-rolled, no YAML dependency: this repo ships zero runtime dependencies
+ * (ADR-0001) and the same reasoning applies to its supply-chain gates.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const EXAMPLE_DIR = "packages/action/examples";
+
+/** Workflow keys GitHub requires to be a boolean. */
+const BOOLEAN_KEYS = new Set([
+  "continue-on-error",
+  "fail-fast",
+  "cancel-in-progress",
+  "submodules",
+]);
+
+/** Our own action, in either of its two `uses:` coordinates. */
+const OWN_ACTION = /^quantakrypto\/pqc-tools(\/packages\/action)?@(.+)$/;
+
+/** A value GitHub will evaluate rather than read literally. */
+const isExpression = (v) => v.startsWith("${{");
+
+/**
+ * Problems in one workflow file. Empty array means it is fine.
+ *
+ * Line-oriented on purpose. A step's keys are `key: value` at a fixed indent, so
+ * the mangling this exists to catch (prose spilling into the next key) shows up
+ * as a scalar that does not fit its key, which is exactly what we test.
+ */
+export function checkWorkflow(text) {
+  const problems = [];
+  const lines = text.split("\n");
+
+  lines.forEach((line, i) => {
+    const n = i + 1;
+    if (/^\s*#/.test(line)) return;
+
+    const m = line.match(/^\s*-?\s*([a-z][a-z0-9-]*):\s*(.*?)\s*(?:#.*)?$/i);
+    if (!m) return;
+    const [, key, rawValue] = m;
+    const value = (rawValue ?? "").replace(/^["']|["']$/g, "");
+    if (!value) return;
+
+    if (BOOLEAN_KEYS.has(key) && !isExpression(value) && value !== "true" && value !== "false") {
+      problems.push(`${n}: ${key} must be true or false, got "${value}"`);
+      return;
+    }
+
+    if (key !== "uses") return;
+
+    if (/\s/.test(value)) {
+      problems.push(`${n}: uses must be a single ref, got "${value}"`);
+      return;
+    }
+    if (!value.includes("@") && !value.startsWith("./")) {
+      problems.push(`${n}: uses is unpinned: "${value}"`);
+      return;
+    }
+    const own = value.match(OWN_ACTION);
+    if (own && !/^v\d+$/.test(own[2])) {
+      problems.push(
+        `${n}: our action must be pinned to a moving major (@v1), got "@${own[2]}". ` +
+          `A copied example lives for years; a semver tag or branch freezes or floats it.`,
+      );
+    }
+  });
+
+  return problems;
+}
+
+function main() {
+  const dir = resolve(ROOT, EXAMPLE_DIR);
+  const files = readdirSync(dir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+
+  // A glob that matched nothing would make this gate pass forever.
+  if (files.length === 0) {
+    console.error(`✗ no example workflows found in ${EXAMPLE_DIR} — the check itself is broken.`);
+    process.exit(1);
+  }
+
+  let failed = false;
+  for (const file of files) {
+    const problems = checkWorkflow(readFileSync(join(dir, file), "utf8"));
+    if (problems.length === 0) continue;
+    failed = true;
+    console.error(`✗ ${EXAMPLE_DIR}/${file}`);
+    for (const p of problems) console.error(`  - ${p}`);
+  }
+  if (failed) {
+    console.error("\nThese files are copy-paste product. A broken one ships to every reader.");
+    process.exit(1);
+  }
+  console.log(`✓ ${files.length} example workflow(s) well-formed and pinned to a moving major.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/test/check-example-workflows.test.mjs
+++ b/scripts/test/check-example-workflows.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { checkWorkflow, EXAMPLE_DIR } from "../check-example-workflows.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("the exact line that shipped is caught", () => {
+  // What was actually committed: a step name merged into the key below it.
+  // Valid YAML, so a parser sees nothing wrong; GitHub rejects the workflow.
+  const problems = checkWorkflow(
+    ["      - name: Upload SARIF", "        continue-on-error: true to code scanning"].join("\n"),
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /continue-on-error must be true or false/);
+});
+
+test("booleans, expressions and quoted booleans all pass", () => {
+  for (const value of ["true", "false", '"true"', "${{ github.event_name == 'schedule' }}"]) {
+    assert.deepEqual(checkWorkflow(`        continue-on-error: ${value}`), [], value);
+  }
+});
+
+test("our action must be pinned to a moving major", () => {
+  for (const ref of ["v1.2.3", "main", "0.10.0"]) {
+    const problems = checkWorkflow(`        uses: quantakrypto/pqc-tools/packages/action@${ref}`);
+    assert.equal(problems.length, 1, ref);
+    assert.match(problems[0], /moving major/);
+  }
+  // Both `uses:` coordinates of our action are accepted at a bare major.
+  assert.deepEqual(checkWorkflow("        uses: quantakrypto/pqc-tools/packages/action@v1"), []);
+  assert.deepEqual(checkWorkflow("        uses: quantakrypto/pqc-tools@v1"), []);
+});
+
+test("third-party actions are not held to our tag rule", () => {
+  assert.deepEqual(checkWorkflow("        uses: github/codeql-action/upload-sarif@v4"), []);
+  assert.deepEqual(checkWorkflow("        uses: actions/checkout@v4"), []);
+});
+
+test("an unpinned or malformed uses is rejected", () => {
+  assert.match(checkWorkflow("        uses: actions/checkout")[0], /unpinned/);
+  assert.match(checkWorkflow("        uses: actions/checkout@v4 extra")[0], /single ref/);
+});
+
+test("comments are not parsed as keys", () => {
+  assert.deepEqual(checkWorkflow("      # continue-on-error: not a real setting here"), []);
+});
+
+test("every shipped example passes", () => {
+  const dir = resolve(ROOT, EXAMPLE_DIR);
+  const files = readdirSync(dir).filter((f) => f.endsWith(".yml"));
+  assert.ok(files.length > 0, "found no examples to check");
+  for (const file of files) {
+    assert.deepEqual(checkWorkflow(readFileSync(join(dir, file), "utf8")), [], file);
+  }
+});


### PR DESCRIPTION
An audit of everything documenting the action after the unified-checks work, plus the guard that would have caught the worst of it.

## The ready-to-copy example was broken

`packages/action/examples/quantum-readiness.yml` contained:

```yaml
      - name: Upload SARIF
        continue-on-error: true to code scanning
```

A step name merged into the key below it. That is valid YAML, so prettier and every parser passed it; GitHub rejects the workflow. Both READMEs point at this file as the thing to copy.

Nothing was checking these files. Unlike `.github/workflows`, GitHub never parses `packages/action/examples`, so a broken one ships silently to every reader. `scripts/check-example-workflows.mjs` now gates them in the supply-chain job:

1. keys that must hold a boolean hold one (this is the bug above);
2. `uses:` is a single well-formed ref;
3. a `uses:` of **our** action pins a bare moving major.

Rule 3 is the one with teeth. A copied example lives for years, so `@v1.2.3` would freeze it on one bundle and `@main` would float it onto unreleased code. It is also what would have caught `@v2` reappearing.

## The README described a qScan-only action

`checks` sat in the input table with no explanation and no worked example, and `ignore` / `include` were missing from the table entirely despite shipping in 0.10.0.

Added a section covering all seven combinations, with the three things worth knowing before turning the other two on: conformance **executes repository code** (the contributor's, on a fork PR), `i-own-this` is a legal statement rather than a flag, and a conformance run that cannot start is a failure rather than a clean sheet.

It also claimed more than the action does. The checks are independent: the SARIF report, the outputs and the exit decision all come from `scan` alone, and a failing battery or a weak endpoint does not fail the build. A misconfiguration still does.

## The platform callback was undocumented

The action makes an outbound request. Anyone reading the source finds it, in a tool sold on "your code never leaves your CI". It is now written down with its constraints: `repository_dispatch` only, our origin only, redirects refused rather than followed, token masked with the runner.

## The infra example claimed an upload it never did

Its header said it uploads SARIF to code scanning. There was no upload step. Added it, with `actions: read`. It keeps qProbe on the CLI on purpose (a host list from a committed manifest, merged into a combined CBOM, neither of which the action's probe check does) and now says so, rather than reading as an oversight.

## Smaller

- Examples move to `codeql-action/upload-sarif@v4`; our own workflows are already there while everything we hand out said `@v3`.
- The `checks` description in both `action.yml` files no longer says "exactly what v1 did", which read as though v1 were a past version.
- `SECURITY.md` said packages are "currently 0.9.x"; `SUPPLY-CHAIN.md` said "as of 0.9.0 (prepared; 0.8.0 published)". 0.10.0 is out.
- `release.yml`'s comment described `v2` as a live tag. It has been deleted: `checks` defaults to `scan`, so it was never a breaking change and never earned a new major. Discovering the `vN` tags rather than naming `v1` stays, so a real future major cannot be left on a stale bundle.

## Verification

`npm run build`, `npm test` (all workspaces + `test:scripts`, 7 new), `npm run lint`, `npm run format:check`, `node scripts/check-action-yml-sync.mjs`, `node scripts/check-example-workflows.mjs`.

Per this repo's rule, **not auto-merged** and left for you.