### PR TITLE
action: run on node24, and settle on one .quantakrypto/ path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22"]
+        # 24 because that is what the Action declares (`using: node24`) and what
+        # GitHub already runs every action on. 20 stays because every package
+        # declares `engines: node >=20`; drop it here only when that drops too.
+        node: ["20", "22", "24"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -152,8 +155,8 @@ jobs:
   action-bundle:
     name: action dist is fresh
     runs-on: ubuntu-latest
-    # Guards against shipping a stale action: the node20 action runs the
-    # committed packages/action/dist/index.js, so if someone edits the source
+    # Guards against shipping a stale action: the action runs the committed
+    # packages/action/dist/index.js, so if someone edits the source
     # and forgets to re-bundle, `uses: …@v1` would silently run old code.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -180,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     # Runs the bundled action the way a consumer does (uses: a local path
-    # resolves the same node20 entrypoint as uses: quantakrypto/pqc-tools/...@v1),
+    # resolves the same entrypoint as uses: quantakrypto/pqc-tools/...@v1),
     # so a runtime break in the action is caught here instead of in the wild.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npx @quantakrypto/sieve --impl "node ./my-impl.js" --param ml-kem-768
 # 4. Gate against a compliance mandate's dated deadlines (CNSA 2.0 / NIST IR 8547).
 #    Verdicts also ride in --format json/sarif/evidence; --policy lets an org
 #    acknowledge families it is knowingly migrating (exempt from early gating).
-npx @quantakrypto/qscan ./ --mandate cnsa-2.0 [--policy crypto-policy.json]
+npx @quantakrypto/qscan ./ --mandate cnsa-2.0 [--policy .quantakrypto/crypto-policy.json]
 ```
 
 Add the CI gate by dropping

--- a/action.yml
+++ b/action.yml
@@ -160,5 +160,5 @@ outputs:
     description: "Post-quantum readiness score from 0 (worst) to 100 (no classical asymmetric crypto found)."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "packages/action/dist/index.js"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -31,6 +31,25 @@ and local runs agree without repeating long flag lists.
 - Exactly **one** config file applies per run; configs do **not** merge across
   directories (no cascading), to keep precedence simple and auditable.
 
+### The `.quantakrypto/` directory
+
+No tool requires it: `--baseline` and `--policy` take any path, and the config
+file itself is discovered at the scan root. But every example in this repository
+writes the files a project commits into **`.quantakrypto/`**:
+
+| File | Path |
+|---|---|
+| Baseline (`--write-baseline` / `--baseline`) | `.quantakrypto/baseline.json` |
+| Org cryptography policy (`--policy`) | `.quantakrypto/crypto-policy.json` |
+| qProbe ownership manifest (`--owned-hosts`) | `.quantakrypto/owned-hosts.txt` |
+
+One convention, so a reader who has seen one of our examples can guess the rest,
+and so a project's quantakrypto state is one reviewable directory rather than
+loose files at the repository root. The docs used to disagree with themselves
+here (`qscan-baseline.json`, `.quantakrypto/baseline.json` and `.qscan/` all
+appeared), which is worth nothing but costs a reader a moment of doubt every
+time.
+
 ## 3. Precedence
 
 Effective options are resolved with a strict, documented order. **Flags beat

--- a/docs/CRYPTO-AGILITY-MANIFEST.md
+++ b/docs/CRYPTO-AGILITY-MANIFEST.md
@@ -152,7 +152,7 @@ qscan crypto-agility emit . -o .well-known/crypto-agility.json
 qscan crypto-agility emit . \
   --attestation https://quantakrypto.com/attest/acme \
   --hybrid-kex \
-  --policy ./crypto-policy.json \
+  --policy .quantakrypto/crypto-policy.json \
   -o .well-known/crypto-agility.json
 ```
 

--- a/docs/adr/0001-zero-runtime-dependencies.md
+++ b/docs/adr/0001-zero-runtime-dependencies.md
@@ -64,4 +64,4 @@ invariant from eroding. The `runtime deps: 0` README badge is a public commitmen
   assurance property.
 - **Bundle dependencies at build time** (vendoring). Rejected for runtime code as
   unnecessary given the built-ins suffice; bundling *is* used for the Action's
-  `dist/` for a different reason (a `node20` action must run committed JS — see).
+  `dist/` for a different reason (a JavaScript action must run committed JS — see).

--- a/docs/adr/0003-monorepo-and-build.md
+++ b/docs/adr/0003-monorepo-and-build.md
@@ -39,8 +39,8 @@ contributors run three commands (`npm install` / `npm run build` / `npm test`).
 - **Project references add ceremony** — each new package needs its `references`
   wired and an entry in the root build. Accepted as the price of correct,
   incremental, contract-first builds.
-- **The Action's `dist/` must be committed/bundled to publish.** A `node20`
-  GitHub Action runs `dist/index.js` directly, so `uses: …/packages/action@v1`
+- **The Action's `dist/` must be committed/bundled to publish.** A JavaScript
+  GitHub Action (`using: node24`) runs `dist/index.js` directly, so `uses: …/packages/action@v1`
   does not work until the built JS is committed or single-file-bundled. **This gap
   is now closed:** `packages/action/dist/index.js` is committed and a CI
   **freshness gate** (`action-bundle` in [ci.yml](../../.github/workflows/ci.yml))

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -156,5 +156,5 @@ outputs:
     description: "Post-quantum readiness score from 0 (worst) to 100 (no classical asymmetric crypto found)."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -16621,7 +16621,7 @@ function setOutput(name, value, env = process.env) {
     });
     return;
   }
-  process.stdout.write(formatCommand("set-output", value, { title: name }) + EOL);
+  process.stdout.write(`quantakrypto: output ${name}=${value}${EOL}`);
 }
 function appendStepSummary(markdown, env = process.env) {
   const filePath = env["GITHUB_STEP_SUMMARY"];

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "bundle": "esbuild src/main.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --banner:js=\"import { createRequire as __cr } from 'module'; const require = __cr(import.meta.url);\"",
+    "bundle": "esbuild src/main.ts --bundle --platform=node --target=node24 --format=esm --outfile=dist/index.js --banner:js=\"import { createRequire as __cr } from 'module'; const require = __cr(import.meta.url);\"",
     "test": "node --import tsx --test test/*.test.ts"
   }
 }

--- a/packages/action/src/io.ts
+++ b/packages/action/src/io.ts
@@ -141,7 +141,20 @@ export function notice(message: string, properties?: AnnotationProperties): void
 /**
  * Set an action output. On a runner this appends `name<<DELIM\nvalue\nDELIM` to
  * the file named by `$GITHUB_OUTPUT`. With no such file (local/test runs) it
- * falls back to a deprecated-but-harmless stdout command so callers still see it.
+ * prints a plain line so callers still see the value.
+ *
+ * The fallback used to write `::set-output title=…::value`, which was wrong in
+ * three ways at once. GitHub REMOVED `set-output` from the runner in 2023, so it
+ * set nothing. Its parameter was `name=`, never `title=`, so the runner rejected
+ * it with "Required field 'name' is missing" and annotated the step. And because
+ * our own unit tests call this without a `GITHUB_OUTPUT`, those commands went to
+ * the real runner's stdout during CI: whether the runner parsed them came down
+ * to how the test reporter's output happened to interleave, so `npm test` could
+ * fail on a line-buffering coincidence. It did, on the Node 24 matrix leg, with
+ * every one of the 1329 tests passing.
+ *
+ * A fallback must never emit a workflow command. Nothing else here is
+ * conditional on being on a runner, so nothing else has this hazard.
  *
  * The heredoc delimiter is a fresh `ghadelimiter_<random-uuid>` per call (as in
  * `@actions/core`) so the value cannot contain a line that matches it. We also
@@ -170,7 +183,7 @@ export function setOutput(name: string, value: string, env: NodeJS.ProcessEnv = 
     });
     return;
   }
-  process.stdout.write(formatCommand("set-output", value, { title: name }) + EOL);
+  process.stdout.write(`quantakrypto: output ${name}=${value}${EOL}`);
 }
 
 /**

--- a/packages/action/test/io.test.ts
+++ b/packages/action/test/io.test.ts
@@ -137,6 +137,33 @@ test("setOutput appends a heredoc entry to $GITHUB_OUTPUT with a random delimite
   assert.doesNotMatch(contents, /ghadelimiter_findings-count/);
 });
 
+/**
+ * The fallback must not be a workflow command.
+ *
+ * It used to write `::set-output title=…::value`: a command GitHub removed in
+ * 2023, spelled with the wrong parameter, so the runner rejected it. Our own
+ * tests call setOutput with no GITHUB_OUTPUT, which put those commands on the
+ * real runner's stdout during CI, and whether the runner parsed them depended on
+ * how output happened to interleave. It failed a matrix leg with 1329 tests
+ * passing. Nothing a test can emit may be a command the runner will read.
+ */
+test("setOutput without $GITHUB_OUTPUT prints a plain line, never a workflow command", () => {
+  const written: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  (process.stdout as any).write = (chunk: any) => {
+    written.push(String(chunk));
+    return true;
+  };
+  try {
+    setOutput("findings-count", "3", {});
+  } finally {
+    (process.stdout as any).write = original;
+  }
+  const out = written.join("");
+  assert.match(out, /findings-count=3/);
+  assert.ok(!out.includes("::"), `fallback emitted a workflow command: ${JSON.stringify(out)}`);
+});
+
 // ---------------------------------------------------------------------------
 // P0: output injection via a forged heredoc delimiter. With the old predictable
 // `ghadelimiter_<name>`, a value containing that exact line could close the

--- a/packages/qscan/README.md
+++ b/packages/qscan/README.md
@@ -166,10 +166,10 @@ timestamps.
 
 ```bash
 # 1. Accept the current state of the world.
-qscan . --write-baseline qscan-baseline.json
+qscan . --write-baseline .quantakrypto/baseline.json
 
 # 2. From now on, fail only on findings that are NOT in the baseline.
-qscan . --baseline qscan-baseline.json
+qscan . --baseline .quantakrypto/baseline.json
 ```
 
 The baseline file is plain JSON:
@@ -368,7 +368,7 @@ jobs:
         with:
           node-version: 20
       - name: Scan for quantum-vulnerable crypto
-        run: npx @quantakrypto/qscan . --severity-threshold high --baseline qscan-baseline.json
+        run: npx @quantakrypto/qscan . --severity-threshold high --baseline .quantakrypto/baseline.json
 
       # Optional: upload SARIF to GitHub code scanning.
       - name: Generate SARIF
@@ -391,7 +391,7 @@ const { result, exitCode, suppressed } = await runQscan({
   path: "src",
   format: "json",
   severityThreshold: "high",
-  baseline: "qscan-baseline.json",
+  baseline: ".quantakrypto/baseline.json",
 });
 
 console.log(`${result.findings.length} findings, exit ${exitCode}`);

--- a/packages/qscan/src/help.ts
+++ b/packages/qscan/src/help.ts
@@ -144,8 +144,8 @@ EXAMPLES
   qscan .                       Scan the current directory
   qscan src --format sarif -o qscan.sarif
   qscan . --severity-threshold critical
-  qscan . --write-baseline qscan-baseline.json
-  qscan . --baseline qscan-baseline.json
+  qscan . --write-baseline .quantakrypto/baseline.json
+  qscan . --baseline .quantakrypto/baseline.json
   qscan . --include src --include lib
   qscan . --config ./ci/quantakrypto.config.json
   qscan . --changed --since origin/main


### PR DESCRIPTION
Items 1 and 3 from the documentation audit. **Stacked on #58** (base is `docs/action-audit`), so merge that one first and this retargets to `main` automatically.

## node24

Both `action.yml` files declared `using: "node20"`. GitHub deprecated that runtime and already force-runs node20 actions on 24, warning on every run of ours:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

Declaring what already happens costs nothing and removes a scheduled break. The esbuild target moves with it, and the re-bundled `dist/index.js` comes out **byte-identical**, which is the evidence that nothing in the action needed downleveling to begin with.

CI gains node 24 in the build matrix, since the action now claims that runtime and nothing was testing it. 20 stays, because every package declares `engines: node >=20`; this matrix drops it when that does.

## One path convention

Our own docs disagreed about where a project's committed files go:

| Where | What it said |
|---|---|
| qScan `--help` and README | `qscan-baseline.json` |
| Action README and example | `.quantakrypto/baseline.json` |
| Root README | `crypto-policy.json` |
| Crypto-agility manifest | `./crypto-policy.json` |
| Website CI guide | `.qscan/crypto-policy.json` |

None of them is wrong, since the flags take any path. Each one costs a reader a moment of doubt.

Everything is `.quantakrypto/` now, which is what `CONFIG.md` and the action already used, and `CONFIG.md` states it as the convention over the three files it covers: baseline, policy, and qProbe's ownership manifest. The qScan CLI's own `--help` moves too, since that is the example most people actually see. (The matching website guide change ships separately.)

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, both supply-chain checks, and `npm run bundle` leaving `dist/` unchanged.