### PR TITLE
ci: bump dependency-review-action to v5.0.0 and scorecard-action to v2.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
       # incompatible license. Zero runtime deps today (ADR-0001), so this guards
       # the dev-tool surface and keeps that invariant from eroding via a PR.
       - name: Dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           # Apache-2.0 project: deny strong-copyleft licenses that would conflict.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Replaces Dependabot's #24 and #41, which could not be merged through the API: the token lacks the `workflow` scope, so GitHub refuses to update anything under `.github/workflows`. Both branches were also weeks stale, so merging them would have dragged an old base through a large diff.

Same SHA-pinned bumps, applied directly on current `main`:

| Action | From | To |
|---|---|---|
| `actions/dependency-review-action` | `2031cfc` v4.9.0 | `a1d282b` v5.0.0 |
| `ossf/scorecard-action` | `62b2cac` v2.4.0 | `2d11466` v2.4.4 |

`node scripts/check-action-pins.mjs` passes, so the Scorecard pinned-dependencies invariant holds.

Close #24 and #41 once this lands.