### PR TITLE
action: actually reduce a URL probe-target to its host

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -13653,6 +13653,20 @@ function parseChecks(raw) {
   }
   return out;
 }
+function normalizeProbeTarget(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    if (url.username || url.password) return trimmed;
+    if (!url.hostname) return trimmed;
+    if (!url.port) return url.hostname.replace(/^\[|\]$/g, "");
+    return `${url.hostname}:${url.port}`;
+  } catch {
+    return trimmed;
+  }
+}
 function assertCheckConfig(checks, cfg) {
   const missing = [];
   if (checks.includes("probe") && !cfg.probeTarget.trim()) {
@@ -16523,7 +16537,7 @@ async function runProbeCheck(target, iOwnThis) {
         'probing requires an ownership attestation: set i-own-this: "true" in the workflow, and only for an endpoint you are authorised to test.'
       );
     }
-    const parsed = parseTarget(target, DEFAULT_PROBE_PORT);
+    const parsed = parseTarget(normalizeProbeTarget(target), DEFAULT_PROBE_PORT);
     const { findings, inventory } = await runProbe({
       targets: [parsed],
       mode: "auto",

--- a/packages/action/src/checks.ts
+++ b/packages/action/src/checks.ts
@@ -50,22 +50,48 @@ export function parseChecks(raw: string): CheckId[] {
 }
 
 /**
- * Reduce whatever was typed to the bare hostname qProbe expects.
+ * Reduce an explicitly-written URL to the host qProbe expects. Anything else is
+ * returned untouched, for qProbe's own parser to accept or refuse.
  *
- * A full URL is the obvious thing to paste, and qProbe refuses it — correctly,
- * since `--i-own-this` is an ownership attestation and `https://mine@theirs.com`
- * resolves to `theirs.com`. Normalising here means the attestation still names
- * one host explicitly, and the host it names is the one that gets probed.
+ * A URL is the obvious thing to paste into `probe-target`, and `action.yml` has
+ * always said one is accepted. It was not: this function existed, was exported,
+ * was tested, and was never called, so `https://example.com` reached qProbe raw
+ * and was refused. A blog repo probing `https://leonacosta.com` failed on every
+ * run for that reason, reported as the generic "Check produced no valid report".
+ *
+ * Why the narrow rule, rather than normalising everything:
+ *
+ * An earlier version of this DID normalise everything, by prepending `https://`
+ * to a bare string and reading the URL's host. That turned
+ * `our-api.example.com@evil.test` into `evil.test`, so a reviewer reading the
+ * committed workflow saw one host attested and a different host was probed.
+ * `i-own-this` is an ownership attestation; the committed line has to name the
+ * host that gets probed.
+ *
+ * So: only a string that already carries a scheme is treated as a URL, and only
+ * when its authority has no userinfo. `https://mine@theirs.com` is refused for
+ * the same reason as the bare form, rather than silently becoming `theirs.com`.
+ * Everything else goes to `parseTarget` unchanged, which is still the single
+ * enforcement point for "one host, named explicitly".
  */
 export function normalizeProbeTarget(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return "";
-  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
   try {
-    // `hostname` keeps IPv6 literals bracketed; qProbe wants the address itself.
-    return new URL(withScheme).hostname.replace(/^\[|\]$/g, "");
+    const url = new URL(trimmed);
+    // Userinfo makes the probed host different from the one a reader sees first.
+    // Hand it back untouched so parseTarget refuses it and says why.
+    if (url.username || url.password) return trimmed;
+    if (!url.hostname) return trimmed;
+    // `hostname` keeps IPv6 literals bracketed. qProbe wants the bare address
+    // when there is no port, and the bracketed form when there is: stripping
+    // the brackets off `[2001:db8::1]:8443` would leave `2001:db8::1:8443`,
+    // which qProbe reads as one long host with the default port.
+    if (!url.port) return url.hostname.replace(/^\[|\]$/g, "");
+    return `${url.hostname}:${url.port}`;
   } catch {
-    return trimmed.split(/[/?#]/)[0]?.split("@").pop()?.split(":")[0] ?? trimmed;
+    return trimmed;
   }
 }
 

--- a/packages/action/src/extra-checks.ts
+++ b/packages/action/src/extra-checks.ts
@@ -1,6 +1,7 @@
 import { runProbe } from "@quantakrypto/qprobe";
 import { parseTarget } from "@quantakrypto/qprobe";
 import { runSieve, type ParamSet } from "@quantakrypto/sieve";
+import { normalizeProbeTarget } from "./checks.js";
 import { conformanceResult, crashedResult, scoredResult } from "./platform.js";
 import type { ResultPayload } from "./platform.js";
 
@@ -49,9 +50,15 @@ export async function runProbeCheck(target: string, iOwnThis: boolean): Promise<
           "and only for an endpoint you are authorised to test.",
       );
     }
+    // An explicitly-written URL is reduced to its host first, which is what
+    // action.yml documents. It is a pure string-to-string step, not a second
+    // parse: whatever comes out still goes through parseTarget below, and
+    // anything that is not a plain scheme://host[:port] comes out unchanged so
+    // parseTarget refuses it. See the note on normalizeProbeTarget.
+    //
     // Throws TargetError with an actionable message on anything that is not a
     // single host (or host:port) named directly.
-    const parsed = parseTarget(target, DEFAULT_PROBE_PORT);
+    const parsed = parseTarget(normalizeProbeTarget(target), DEFAULT_PROBE_PORT);
     const { findings, inventory } = await runProbe({
       targets: [parsed],
       mode: "auto",

--- a/packages/action/test/checks.test.ts
+++ b/packages/action/test/checks.test.ts
@@ -81,15 +81,44 @@ test("does not require config for checks that were not selected", () => {
   assert.doesNotThrow(() => assertCheckConfig(["scan"], { probeTarget: "", conformanceImpl: "" }));
 });
 
-test("normalizes a probe target to a bare host", () => {
+test("reduces an explicitly-written URL to the host qProbe takes", () => {
   assert.equal(normalizeProbeTarget("https://leonacosta.com"), "leonacosta.com");
-  assert.equal(normalizeProbeTarget("api.example.com"), "api.example.com");
-  assert.equal(normalizeProbeTarget("https://api.example.com:8443/v1?x=1#t"), "api.example.com");
-  // Credentials must not survive into a committed workflow or an attestation.
-  assert.equal(normalizeProbeTarget("https://user:secret@api.example.com/p"), "api.example.com");
-  assert.equal(normalizeProbeTarget("https://[2001:db8::1]:443/"), "2001:db8::1");
-  assert.equal(normalizeProbeTarget("  example.com  "), "example.com");
-  assert.equal(normalizeProbeTarget(""), "");
+  assert.equal(normalizeProbeTarget("https://api.example.com/v1?x=1#t"), "api.example.com");
+  // A non-default port is meaningful to qProbe, so it survives.
+  assert.equal(normalizeProbeTarget("https://api.example.com:8443/v1"), "api.example.com:8443");
+  // IPv6 keeps its brackets when a port follows, or qProbe reads the whole
+  // thing as one host on the default port.
+  assert.equal(normalizeProbeTarget("https://[2001:db8::1]:8443/"), "[2001:db8::1]:8443");
+  assert.equal(normalizeProbeTarget("https://[2001:db8::1]/"), "2001:db8::1");
+  assert.equal(normalizeProbeTarget("  https://example.com  "), "example.com");
+});
+
+test("leaves anything that is not a plain URL for parseTarget to judge", () => {
+  for (const raw of ["api.example.com", "api.example.com:8443", "  example.com  ", ""]) {
+    assert.equal(normalizeProbeTarget(raw), raw.trim(), raw);
+  }
+});
+
+/**
+ * The rule that makes this safe to call at all.
+ *
+ * `i-own-this` attests to the target as written in the committed workflow, so
+ * the host a reviewer reads has to be the host that gets probed. An earlier
+ * version normalised EVERYTHING by prepending a scheme, which turned
+ * `our-api.example.com@evil.test` into `evil.test`: a probe of someone else's
+ * endpoint under a manufactured attestation, invisible in review.
+ *
+ * Both forms now come out unchanged, so parseTarget refuses them and says why.
+ */
+test("never resolves userinfo into a different host", () => {
+  for (const hostile of [
+    "our-api.example.com@evil.test",
+    "https://our-api.example.com@evil.test",
+    "https://user:secret@evil.test/p",
+  ]) {
+    assert.equal(normalizeProbeTarget(hostile), hostile, hostile);
+    assert.ok(!normalizeProbeTarget(hostile).startsWith("evil.test"), hostile);
+  }
 });
 
 /**
@@ -139,4 +168,38 @@ test("an unset pattern list is empty, not a pattern matching everything", () => 
   assert.deepEqual(splitPatterns(""), []);
   assert.deepEqual(splitPatterns("   "), []);
   assert.deepEqual(splitPatterns(",\n,"), []);
+});
+
+/**
+ * The wiring, not just the helper.
+ *
+ * `normalizeProbeTarget` was exported, documented in both action.yml files, and
+ * covered by these tests, while nothing called it. A URL therefore reached
+ * qProbe raw and was refused, and the legacy workflow reported that as a bare
+ * "Check produced no valid report". Every one of those tests passed throughout.
+ *
+ * So this asserts the path an operator actually takes: a URL in `probe-target`
+ * must not fail with a target error. It reaches the network, which is why the
+ * assertion is on what the failure ISN'T.
+ */
+test("a URL in probe-target gets past target parsing", async () => {
+  const { runProbeCheck } = await import("../src/extra-checks.js");
+  const viaUrl = await runProbeCheck("https://example.invalid", true);
+  const viaHost = await runProbeCheck("example.invalid", true);
+  for (const r of [viaUrl, viaHost]) {
+    assert.doesNotMatch(r.summary, /takes a host, not a URL/);
+    assert.doesNotMatch(r.summary, /CIDR/);
+  }
+});
+
+test("a hostile target is still refused, URL-shaped or not", async () => {
+  const { runProbeCheck } = await import("../src/extra-checks.js");
+  for (const hostile of [
+    "our-api.example.com@evil.test",
+    "https://our-api.example.com@evil.test",
+  ]) {
+    const r = await runProbeCheck(hostile, true);
+    assert.equal(r.status, "failed", hostile);
+    assert.match(r.summary, /qProbe did not produce a result/, hostile);
+  }
 });


### PR DESCRIPTION
Found by chasing why [a probe run in leonacostaok-blog](https://github.com/dandelionlabs-io/leonacostaok-blog/actions/runs/31169919981) reads as failing.

## Documented behaviour that did not exist

Both `action.yml` files say:

> Hostname of a TLS/SSH endpoint you own, e.g. api.example.com. **A full URL is accepted and reduced to its host.**

It was not. `normalizeProbeTarget` existed, was exported, was documented in two places, and had its own passing test block. **Nothing called it.** I left it behind when I routed the target through qProbe's own parser to close the attestation bypass, and the tests kept passing because they only ever exercised the helper in isolation.

So a URL reached qProbe raw and was refused. That is why the blog repo, which probes `https://leonacosta.com`, has failed every run since it was set up, and why the dashboard says "Check produced no valid report" while the GitHub run shows green.

## The fix, and why it is narrow

The normaliser is now called, and narrowed so that calling it is safe:

- only a string that **already carries a scheme** is treated as a URL;
- and only when its authority has **no userinfo**;
- everything else goes to `parseTarget` unchanged, so that stays the single enforcement point for "one host, named explicitly".

That distinction is the entire security argument. The earlier version prepended `https://` to a **bare** string, so `our-api.example.com@evil.test` became `evil.test`: someone else's endpoint probed under a manufactured `i-own-this`, while a reviewer reading the committed workflow saw `our-api`. Both that form and its URL-shaped twin now come out unchanged and are refused with a reason.

## Tests

The new ones cover the **wiring**, not just the helper, which is precisely what was missing:

- a URL in `probe-target` must not fail with a target error;
- a hostile target must still fail, URL-shaped or not.

Also keeps IPv6 brackets when a port follows: `[2001:db8::1]:8443` stripped to `2001:db8::1:8443` reads to qProbe as one long host on the default port.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, `dist/` re-bundled.