### PR TITLE
action: carry the remediation into the result payload

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -16455,7 +16455,8 @@ function toPayloadFindings(findings) {
     ...f.severity ? { severity: f.severity } : {},
     ...f.location?.file ? { file: f.location.file } : {},
     ...typeof f.location?.line === "number" ? { line: f.location.line } : {},
-    ...f.title ? { message: f.title } : {}
+    ...f.title ? { message: f.title } : {},
+    ...f.remediation ? { remediation: f.remediation } : {}
   }));
 }
 function scoredResult(tool, score, findings) {
@@ -16487,7 +16488,8 @@ function conformanceResult(report2, workflowPath) {
         {
           rule: "harness/implementation-not-runnable",
           severity: "high",
-          message: `Sieve could not run the implementation under test, so this run says nothing about conformance. First error: ${failing[0]?.message ?? "unknown"}. Point conformance-impl (currently: ${impl || "unset"}) at a real executable in this repository, in ${workflowPath}.`
+          message: `Sieve could not run the implementation under test, so this run says nothing about conformance. First error: ${failing[0]?.message ?? "unknown"}.`,
+          remediation: `Point conformance-impl (currently: ${impl || "unset"}) at a real executable in this repository, in ${workflowPath}, then re-run.`
         }
       ]
     };

--- a/packages/action/src/platform.ts
+++ b/packages/action/src/platform.ts
@@ -32,6 +32,17 @@ export interface PayloadFinding {
   file?: string;
   line?: number;
   message?: string;
+  /**
+   * What to do about it.
+   *
+   * Every detector already produces this, either explicitly or derived from the
+   * algorithm family, and it is in the JSON report and the SARIF `help` text.
+   * It was not in this payload, so the platform showed people a list of
+   * problems and no next step, while the tool that found them knew one all
+   * along. "Your readiness is 97, here is why, here is what raises it" is the
+   * whole job; without this the platform could only do the first two thirds.
+   */
+  remediation?: string;
 }
 
 /**
@@ -124,6 +135,7 @@ export function toPayloadFindings(
     ruleId?: string;
     severity?: string;
     title?: string;
+    remediation?: string;
     location?: { file?: string; line?: number };
   }[],
 ): PayloadFinding[] {
@@ -133,6 +145,7 @@ export function toPayloadFindings(
     ...(f.location?.file ? { file: f.location.file } : {}),
     ...(typeof f.location?.line === "number" ? { line: f.location.line } : {}),
     ...(f.title ? { message: f.title } : {}),
+    ...(f.remediation ? { remediation: f.remediation } : {}),
   }));
 }
 
@@ -203,8 +216,10 @@ export function conformanceResult(
           severity: "high",
           message:
             `Sieve could not run the implementation under test, so this run says nothing about ` +
-            `conformance. First error: ${failing[0]?.message ?? "unknown"}. Point conformance-impl ` +
-            `(currently: ${impl || "unset"}) at a real executable in this repository, in ${workflowPath}.`,
+            `conformance. First error: ${failing[0]?.message ?? "unknown"}.`,
+          remediation:
+            `Point conformance-impl (currently: ${impl || "unset"}) at a real executable in this ` +
+            `repository, in ${workflowPath}, then re-run.`,
         },
       ],
     };

--- a/packages/action/test/platform.test.ts
+++ b/packages/action/test/platform.test.ts
@@ -128,8 +128,10 @@ test("a conformance run that never executed is reported as failed, not as a verd
   // 35 identical failures collapse to the one actionable item.
   assert.equal(r.findings.length, 1);
   assert.equal(r.findings[0]?.rule, "harness/implementation-not-runnable");
-  assert.match(r.findings[0]?.message ?? "", /node \.\/my-impl\.js/);
-  assert.match(r.findings[0]?.message ?? "", /quantakrypto\.yml/);
+  // The impl command and the file to edit are the instruction, so they live in
+  // `remediation` rather than in the description of what went wrong.
+  assert.match(r.findings[0]?.remediation ?? "", /node \.\/my-impl\.js/);
+  assert.match(r.findings[0]?.remediation ?? "", /quantakrypto\.yml/);
   assert.doesNotMatch(r.summary, /FAIL/);
 });
 
@@ -270,4 +272,56 @@ test("only a repository_dispatch may carry a platform payload", () => {
   assert.ok(readDispatchContext({ ...env, GITHUB_EVENT_NAME: "repository_dispatch" }));
   assert.equal(readDispatchContext({ ...env, GITHUB_EVENT_NAME: "pull_request" }), null);
   assert.equal(readDispatchContext({ ...env, GITHUB_EVENT_NAME: "workflow_dispatch" }), null);
+});
+
+/**
+ * The remediation has to survive the boundary.
+ *
+ * Every detector produces one, explicitly or derived from the algorithm family,
+ * and it is in the JSON report and the SARIF help text. It was dropped here, so
+ * the platform showed a list of problems and no next step while the tool that
+ * found them knew one all along. A repository probing a host with a classical
+ * certificate sees "readiness 97" and one low finding, and the thing that would
+ * tell them whether 97 is actionable ("plan migration to ML-DSA-65 as your CA
+ * adds support" - i.e. wait) never left the runner.
+ */
+test("toPayloadFindings carries the remediation", () => {
+  const [f] = toPayloadFindings([
+    {
+      ruleId: "qprobe-tls-classical-cert",
+      severity: "low",
+      title: "Classical certificate key",
+      remediation:
+        "Plan migration to ML-DSA-65 (FIPS 204) certificate keys as your CA adds support.",
+      location: { file: "example.com:443", line: 1 },
+    },
+  ]);
+  assert.equal(
+    f?.remediation,
+    "Plan migration to ML-DSA-65 (FIPS 204) certificate keys as your CA adds support.",
+  );
+});
+
+test("toPayloadFindings omits the remediation when there is none, rather than sending empty", () => {
+  const [f] = toPayloadFindings([{ ruleId: "r", severity: "low", title: "t" }]);
+  assert.ok(!("remediation" in (f ?? {})));
+});
+
+test("an unrunnable conformance harness says what to do, separately from what happened", () => {
+  const r = conformanceResult(
+    {
+      param: "ml-kem-768",
+      overall: "ERROR",
+      impl: ["node", "./missing.js"],
+      counts: { pass: 0, fail: 2 },
+      categories: [{ category: "kat", checks: [{ name: "a", status: "fail", detail: "ENOENT" }] }],
+    },
+    ".github/workflows/quantakrypto.yml",
+  );
+  // The message is the diagnosis; the remediation is the instruction. Keeping
+  // them apart is what lets the UI render "what to do" as its own thing.
+  assert.match(r.findings[0]?.message ?? "", /says nothing about conformance/);
+  assert.doesNotMatch(r.findings[0]?.message ?? "", /Point conformance-impl/);
+  assert.match(r.findings[0]?.remediation ?? "", /Point conformance-impl/);
+  assert.match(r.findings[0]?.remediation ?? "", /quantakrypto\.yml/);
 });


### PR DESCRIPTION
Half of "how does a user know the steps to get to 100". The website half follows.

## The gap

Every detector produces a `remediation`, explicitly or derived from the algorithm family. It is in the JSON report and in the SARIF `help` text. It was **not** in the payload we POST to the platform, which mapped `rule, severity, file, line, message` and dropped it.

So the platform received a list of problems and no next step, while the tool that found them knew one all along.

The effect is concrete: a repo probing a host with a classical certificate gets readiness 97 and one `low` finding, and the sentence that tells them whether 97 is worth acting on

> Plan migration to ML-DSA-65 (FIPS 204) certificate keys as your CA adds support.

never left the runner. That sentence is the whole answer to "is 97 my fault or my CA's".

## Also

The unrunnable-conformance finding split its one string in two: the `message` says what happened, the `remediation` says what to do. They were concatenated, so a UI could only ever print the whole paragraph as a problem description.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, `dist/` re-bundled. Three new tests, and the existing conformance test moved its assertions to the field the text now lives in.