### PR TITLE
release: 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-10
+
+Minor: user-facing fixes to the Action, and the runtime it declares. Nothing
+existing changes shape, and no exit code moves.
+
+### Fixed - a URL in the Action's `probe-target` was refused, despite the docs
+
+Both `action.yml` files have always said "A full URL is accepted and reduced to
+its host". It was not. `normalizeProbeTarget` existed, was exported, was
+documented, and had its own passing tests, and nothing ever called it: it was
+left behind when the target was routed through qProbe's own parser to close an
+attestation bypass. So `probe-target: "https://example.com"` reached qProbe raw
+and was refused, and the run reported as a generic failure.
+
+It is now called, and narrowed so that calling it is safe. Only a string that
+already carries a scheme is treated as a URL, and only when its authority has no
+userinfo; everything else goes to `parseTarget` unchanged. That keeps
+`our-api.example.com@evil.test` refused rather than silently resolving to
+`evil.test` under a manufactured `i-own-this`.
+
+### Fixed - qProbe reported the wrong tool version in every JSON report and CBOM
+
+`packages/qprobe/src/version.ts` carried `0.7.0` while the package was at
+`0.10.0`. The only thing keeping it honest was a comment. Every qProbe JSON
+report and endpoint CBOM since 0.8.0 has carried a `toolVersion` that lies about
+the build, which is evidence data. Fixed, and the lockstep test core has always
+had is now on qProbe too.
+
+### Added - the result payload carries each finding's remediation
+
+Every detector produces a remediation, explicitly or derived from the algorithm
+family, and it rides in the JSON report and the SARIF `help` text. It was not in
+the payload posted to quantakrypto.com, so the platform received a list of
+problems and no next step while the tool that found them knew one. The
+unrunnable-conformance finding splits accordingly: `message` says what happened,
+`remediation` says what to do.
+
+### Changed - the Action runs on Node 24
+
+Both `action.yml` files declared `using: "node20"`. GitHub deprecated that
+runtime and already force-runs node20 actions on 24, warning on every run.
+Declaring what already happens removes a scheduled break. The re-bundled
+`dist/index.js` is byte-identical, so nothing needed downleveling. CI gains a
+node 24 leg, which found a real bug on its first run: the `setOutput` fallback
+wrote `::set-output`, a workflow command GitHub removed in 2023 and which it
+rejects, from unit tests onto the real runner's stdout. Whether the runner
+parsed it came down to output interleaving.
+
+### Docs
+
+The ready-to-copy `examples/quantum-readiness.yml` was syntactically broken
+(`continue-on-error: true to code scanning`) and nothing checked it; a new
+supply-chain gate now validates the examples and requires our own action to be
+pinned to a bare moving major. The Action README documents `checks`,
+`ignore`/`include`, and what the platform callback does. Every path example is
+`.quantakrypto/`, which `docs/CONFIG.md` now states as the convention. The
+short-lived `v2` Action tag is deleted: `checks` defaults to `scan`, so it was
+never a breaking change and never earned a new major.
+
 ## [0.10.0] - 2026-08-08
 
 Minor: three additive features and two user-facing bug fixes. Nothing existing

--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,13 +2184,13 @@
     },
     "packages/action": {
       "name": "@quantakrypto/action",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.9.0",
-        "@quantakrypto/qprobe": "0.9.0",
-        "@quantakrypto/qscan": "0.9.0",
-        "@quantakrypto/sieve": "0.9.0"
+        "@quantakrypto/core": "0.11.0",
+        "@quantakrypto/qprobe": "0.11.0",
+        "@quantakrypto/qscan": "0.11.0",
+        "@quantakrypto/sieve": "0.11.0"
       },
       "devDependencies": {
         "esbuild": "0.28.1"
@@ -2201,10 +2201,10 @@
     },
     "packages/agent": {
       "name": "@quantakrypto/agent",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.9.0"
+        "@quantakrypto/core": "0.11.0"
       },
       "engines": {
         "node": ">=20"
@@ -2212,7 +2212,7 @@
     },
     "packages/core": {
       "name": "@quantakrypto/core",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -2220,11 +2220,11 @@
     },
     "packages/mcp": {
       "name": "@quantakrypto/mcp",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.9.0",
-        "@quantakrypto/qprobe": "0.9.0"
+        "@quantakrypto/core": "0.11.0",
+        "@quantakrypto/qprobe": "0.11.0"
       },
       "bin": {
         "quantakrypto-mcp": "dist/stdio.js"
@@ -2235,10 +2235,10 @@
     },
     "packages/qprobe": {
       "name": "@quantakrypto/qprobe",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.9.0"
+        "@quantakrypto/core": "0.11.0"
       },
       "bin": {
         "qprobe": "dist/cli.js"
@@ -2249,11 +2249,11 @@
     },
     "packages/qscan": {
       "name": "@quantakrypto/qscan",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/agent": "0.9.0",
-        "@quantakrypto/core": "0.9.0"
+        "@quantakrypto/agent": "0.11.0",
+        "@quantakrypto/core": "0.11.0"
       },
       "bin": {
         "qremediate": "dist/remediate-bin.js",
@@ -2265,7 +2265,7 @@
     },
     "packages/sieve": {
       "name": "@quantakrypto/sieve",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "bin": {
         "sieve": "dist/cli.js"

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -26,7 +26,7 @@ var VERSION;
 var init_version = __esm({
   "../core/dist/version.js"() {
     "use strict";
-    VERSION = "0.10.0";
+    VERSION = "0.11.0";
   }
 });
 

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/action",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "quantakrypto Action — fail CI when new quantum-vulnerable cryptography lands. GitHub Action wrapping qScan.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -25,10 +25,10 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.10.0",
-    "@quantakrypto/qprobe": "0.10.0",
-    "@quantakrypto/qscan": "0.10.0",
-    "@quantakrypto/sieve": "0.10.0"
+    "@quantakrypto/core": "0.11.0",
+    "@quantakrypto/qprobe": "0.11.0",
+    "@quantakrypto/qscan": "0.11.0",
+    "@quantakrypto/sieve": "0.11.0"
   },
   "devDependencies": {
     "esbuild": "0.28.1"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/agent",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "BYOK LLM client for qScan triage and remediation. Native fetch, zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.10.0"
+    "@quantakrypto/core": "0.11.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared post-quantum readiness library: crypto detectors, vulnerable-dependency database, inventory + SARIF reporting. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -3,4 +3,4 @@
  * the scan orchestrator can import it without creating a cycle through index.ts.
  * Keep in sync with packages/core/package.json.
  */
-export const VERSION = "0.10.0";
+export const VERSION = "0.11.0";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "mcpName": "io.github.quantakrypto/pqc-tools",
   "description": "quantakrypto MCP — post-quantum readiness for AI coding agents via the Model Context Protocol. Zero runtime dependencies (stdio JSON-RPC implemented in-house).",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.10.0",
-    "@quantakrypto/qprobe": "0.10.0"
+    "@quantakrypto/core": "0.11.0",
+    "@quantakrypto/qprobe": "0.11.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/package.json
+++ b/packages/qprobe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qprobe",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "qProbe — actively inspect live TLS/SSH endpoints you OWN for post-quantum readiness (hybrid KEX, classical certs). Gated behind an ownership attestation. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.10.0"
+    "@quantakrypto/core": "0.11.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/src/version.ts
+++ b/packages/qprobe/src/version.ts
@@ -1,2 +1,9 @@
-/** qProbe version, surfaced in JSON output. Keep in sync with package.json. */
-export const VERSION = "0.7.0";
+/**
+ * qProbe version, surfaced in JSON output.
+ *
+ * Kept in lockstep with package.json by version.test.ts. It used to say only
+ * "keep in sync with package.json", and it had drifted four minors: every
+ * qProbe JSON report and every endpoint CBOM since 0.8.0 carried toolVersion
+ * 0.7.0, which is evidence data, not cosmetics.
+ */
+export const VERSION = "0.11.0";

--- a/packages/qprobe/test/version.test.ts
+++ b/packages/qprobe/test/version.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Guards that the hand-maintained `VERSION` constant stays in lockstep with
+ * `package.json`. The two are separate on purpose (the constant avoids an
+ * import cycle through index.ts and lets reporters embed the version without
+ * reading disk), but that means a release bump has to touch both — forget one
+ * and every qProbe report and endpoint CBOM ships a version that lies about the build. This
+ * test fails the release before that can happen.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { VERSION } from "../src/version.js";
+
+test("VERSION matches package.json", async () => {
+  const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+    version: string;
+  };
+  assert.equal(
+    VERSION,
+    pkg.version,
+    `src/version.ts VERSION (${VERSION}) is out of sync with package.json (${pkg.version}) — bump both`,
+  );
+});

--- a/packages/qscan/package.json
+++ b/packages/qscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qscan",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "qScan — find quantum-vulnerable cryptography in any codebase (CLI). Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,8 +37,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/agent": "0.10.0",
-    "@quantakrypto/core": "0.10.0"
+    "@quantakrypto/agent": "0.11.0",
+    "@quantakrypto/core": "0.11.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/sieve/package.json
+++ b/packages/sieve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/sieve",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Sieve — conformance battery for ML-KEM / ML-DSA implementations. Drives any implementation over a simple stdin/stdout JSON protocol. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",


### PR DESCRIPTION
Ships the Action fixes that have been sitting on `main`. They only reach anyone when a release moves the `v1` tag, so until this is published every consumer is still running the 0.10.0 bundle.

## What ships

| | |
|---|---|
| **Fixed** | A URL in `probe-target` is finally reduced to its host, as both `action.yml` files have always claimed. `normalizeProbeTarget` was exported, documented and tested, and never called. (#62) |
| **Fixed** | qProbe's own `VERSION` said `0.7.0` while the package was at `0.10.0`. Every qProbe JSON report and endpoint CBOM since 0.8.0 carried a `toolVersion` that lies about the build. That is evidence data. |
| **Added** | The result payload carries each finding's `remediation`. (#63) |
| **Changed** | The Action declares `node24`, which GitHub already runs it on. Re-bundled `dist` is byte-identical. (#60) |
| **Fixed** | The `setOutput` fallback no longer writes `::set-output`, a workflow command GitHub removed in 2023, onto the runner's stdout from unit tests. |
| **Docs** | The copy-paste example was syntactically broken and nothing checked it; a supply-chain gate now validates the examples. `.quantakrypto/` is the stated path convention. The short-lived `v2` tag is deleted. (#58) |

## The version-drift fix

`packages/qprobe/src/version.ts` had one comment keeping it honest: "Keep in sync with package.json". It had drifted four minors. `@quantakrypto/core` has had a lockstep test for this the whole time; qProbe now has the same one, so the next drift fails the release instead of shipping.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, plus every release gate: `check-zero-deps`, `check-action-yml-sync`, `check-example-workflows`, `api:check`, `repro:check` (all 6 packages reproducible). `dist/` re-bundled.

Merging this does **not** publish. Publishing a GitHub Release for `v0.11.0` runs `release.yml`, which publishes the six public packages to npm with provenance and moves the `v1` Action tag.