### PR TITLE
action: send the baseline fingerprint with each finding

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -16414,6 +16414,7 @@ async function runSieve(opts) {
 }
 
 // src/platform.ts
+init_dist();
 import { readFileSync as readFileSync2 } from "node:fs";
 var RESULT_ORIGIN = "https://quantakrypto.com";
 var POST_TIMEOUT_MS = 1e4;
@@ -16456,8 +16457,16 @@ function toPayloadFindings(findings) {
     ...f.location?.file ? { file: f.location.file } : {},
     ...typeof f.location?.line === "number" ? { line: f.location.line } : {},
     ...f.title ? { message: f.title } : {},
-    ...f.remediation ? { remediation: f.remediation } : {}
+    ...f.remediation ? { remediation: f.remediation } : {},
+    ...fingerprintOf(f) ? { fingerprint: fingerprintOf(f) } : {}
   }));
+}
+function fingerprintOf(f) {
+  if (!f.ruleId || !f.location?.file) return void 0;
+  return fingerprintFinding({
+    ruleId: f.ruleId,
+    location: { file: f.location.file, snippet: f.location.snippet }
+  });
 }
 function scoredResult(tool, score, findings) {
   const n = findings.length;

--- a/packages/action/src/platform.ts
+++ b/packages/action/src/platform.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { fingerprintFinding } from "@quantakrypto/core";
+
 /**
  * Reporting a check result back to quantakrypto.com.
  *
@@ -32,6 +34,20 @@ export interface PayloadFinding {
   file?: string;
   line?: number;
   message?: string;
+  /**
+   * Stable identity for this finding across runs.
+   *
+   * The same SHA-256 of (rule, file, normalized snippet) that the baseline uses,
+   * deliberately excluding line and column so an unrelated edit that shifts code
+   * up or down a file does not resurface a finding as new.
+   *
+   * The platform needs it to say anything durable about a specific finding:
+   * "this one is accepted risk until March", "this one is the same one you saw
+   * last week". Without it the platform falls back to rule + path, which breaks
+   * the moment the code moves file and cannot tell two hits of one rule in one
+   * file apart.
+   */
+  fingerprint?: string;
   /**
    * What to do about it.
    *
@@ -136,7 +152,7 @@ export function toPayloadFindings(
     severity?: string;
     title?: string;
     remediation?: string;
-    location?: { file?: string; line?: number };
+    location?: { file?: string; line?: number; snippet?: string };
   }[],
 ): PayloadFinding[] {
   return findings.slice(0, MAX_FINDINGS).map((f) => ({
@@ -146,7 +162,30 @@ export function toPayloadFindings(
     ...(typeof f.location?.line === "number" ? { line: f.location.line } : {}),
     ...(f.title ? { message: f.title } : {}),
     ...(f.remediation ? { remediation: f.remediation } : {}),
+    ...(fingerprintOf(f) ? { fingerprint: fingerprintOf(f) } : {}),
   }));
+}
+
+/**
+ * The finding's baseline fingerprint, when we have enough to compute one.
+ *
+ * Reuses core's `fingerprintFinding` rather than hashing here, so the id the
+ * platform stores is the SAME id `qscan --write-baseline` produces. One
+ * identity for a finding across CI and the dashboard, not two that agree until
+ * one of them is edited.
+ *
+ * qProbe findings have no snippet; the hash is still stable for them because
+ * the rule and the target host are.
+ */
+function fingerprintOf(f: {
+  ruleId?: string;
+  location?: { file?: string; snippet?: string };
+}): string | undefined {
+  if (!f.ruleId || !f.location?.file) return undefined;
+  return fingerprintFinding({
+    ruleId: f.ruleId,
+    location: { file: f.location.file, snippet: f.location.snippet },
+  } as Parameters<typeof fingerprintFinding>[0]);
 }
 
 /** A scored check (qScan, qProbe): score plus findings. */

--- a/packages/action/test/platform.test.ts
+++ b/packages/action/test/platform.test.ts
@@ -81,7 +81,9 @@ test("maps findings to the payload shape and caps them", () => {
   }));
   const out = toPayloadFindings(many);
   assert.equal(out.length, 200, "must not post more than the server keeps");
-  assert.deepEqual(out[0], { rule: "r0", severity: "high", file: "a.ts", line: 0, message: "t" });
+  const { fingerprint, ...fields } = out[0] ?? {};
+  assert.deepEqual(fields, { rule: "r0", severity: "high", file: "a.ts", line: 0, message: "t" });
+  assert.match(fingerprint ?? "", /^[0-9a-f]{64}$/, "a finding with a file carries a fingerprint");
 });
 
 test("omits absent fields rather than emitting nulls", () => {
@@ -324,4 +326,52 @@ test("an unrunnable conformance harness says what to do, separately from what ha
   assert.doesNotMatch(r.findings[0]?.message ?? "", /Point conformance-impl/);
   assert.match(r.findings[0]?.remediation ?? "", /Point conformance-impl/);
   assert.match(r.findings[0]?.remediation ?? "", /quantakrypto\.yml/);
+});
+
+/**
+ * The platform cannot say anything durable about a specific finding without a
+ * stable id for it. "Accepted risk until March" and "this is the same one you
+ * saw last week" both need one, and the payload carried none, so the platform
+ * fell back to rule + path: broken the moment the code moves file, and unable
+ * to tell two hits of one rule in one file apart.
+ *
+ * It must be the SAME id `qscan --write-baseline` writes, so CI and the
+ * dashboard agree on what a finding is rather than each having its own idea.
+ */
+test("toPayloadFindings carries the baseline fingerprint", async () => {
+  const { fingerprintFinding } = await import("@quantakrypto/core");
+  const finding = {
+    ruleId: "python-rsa-keygen",
+    severity: "high",
+    title: "RSA key generation",
+    location: { file: "src/crypto.py", line: 12, snippet: "rsa.generate_private_key(" },
+  };
+  const [out] = toPayloadFindings([finding]);
+  assert.equal(
+    out?.fingerprint,
+    fingerprintFinding(finding as Parameters<typeof fingerprintFinding>[0]),
+  );
+});
+
+/** Line and column are excluded, so unrelated edits do not resurface a finding. */
+test("the fingerprint survives the finding moving down the file", () => {
+  const at = (line: number) =>
+    toPayloadFindings([
+      {
+        ruleId: "python-rsa-keygen",
+        location: { file: "src/crypto.py", line, snippet: "rsa.generate_private_key(" },
+      },
+    ])[0]?.fingerprint;
+  assert.equal(at(12), at(300));
+});
+
+test("two different rules in one file get different fingerprints", () => {
+  const [a] = toPayloadFindings([{ ruleId: "a", location: { file: "f.py", snippet: "x" } }]);
+  const [b] = toPayloadFindings([{ ruleId: "b", location: { file: "f.py", snippet: "x" } }]);
+  assert.notEqual(a?.fingerprint, b?.fingerprint);
+});
+
+test("a finding with no file is sent without a fingerprint rather than a fake one", () => {
+  const [out] = toPayloadFindings([{ ruleId: "harness/implementation-not-runnable" }]);
+  assert.ok(!("fingerprint" in (out ?? {})));
 });


### PR DESCRIPTION
Groundwork for per-finding exceptions on the platform ("accepted risk until March"). Same class of bug as the remediation: the tools compute it, the payload dropped it.

## Why it matters

`qscan --write-baseline` identifies a finding by hashing (rule, file, normalized snippet), deliberately **excluding line and column** so an unrelated edit that shifts code down a file does not resurface it as new. That id never reached the platform, so it fell back to `rule | normalizedPath`, which:

- breaks the moment the code moves file;
- cannot tell two hits of one rule in one file apart.

Fine for a rough "is this the same finding as last week". Not fine for anything durable: an exception keyed on a path silently lapses on the next refactor, and it lapses **quietly**, which is the worst way for a suppression to fail.

## The identity is shared, not parallel

It reuses core's `fingerprintFinding` rather than hashing here, so the id the platform stores is the same one `--write-baseline` writes. One identity for a finding across CI and the dashboard, instead of two that agree right up until one of them is edited.

Omitted rather than faked when there is no file to hash, which is the conformance-harness case.

## Tests

- carries exactly `fingerprintFinding`'s output, asserted against the real function;
- survives the finding moving from line 12 to line 300;
- two rules in one file get different fingerprints;
- a finding with no file is sent without one.

The existing cap test caught the change (its `deepEqual` no longer matched) and now asserts the shape plus a 64-hex fingerprint.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, `check-zero-deps`, `dist/` re-bundled.