### PR TITLE
action: send the crypto inventory with the scan result

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -16677,13 +16677,29 @@ function fingerprintOf(f) {
     location: { file: f.location.file, snippet: f.location.snippet }
   });
 }
-function scoredResult(tool, score, findings) {
+function scoredResult(tool, score, findings, assets) {
   const n = findings.length;
   return {
     status: "complete",
     score,
     summary: `${tool}: ${n} finding(s), readiness ${score ?? "?"}/100`,
-    findings: toPayloadFindings(findings)
+    findings: toPayloadFindings(findings),
+    // Capped for the same reason the findings are: this is evidence, not a
+    // dump. An inventory with more distinct algorithms than this is not a
+    // repository, it is a corpus.
+    ...assets?.length ? { assets: assets.slice(0, MAX_ASSETS).map(toPayloadAsset) } : {}
+  };
+}
+var MAX_ASSETS = 100;
+function toPayloadAsset(a) {
+  return {
+    algorithm: a.algorithm,
+    kind: a.kind,
+    posture: a.posture,
+    count: a.count,
+    // A few example sites, not every one: the count already carries the scale,
+    // and the locations are only there so a reader can go and look.
+    locations: (a.locations ?? []).slice(0, 5).map((l) => ({ file: l.file, line: l.line }))
   };
 }
 function conformanceResult(report2, workflowPath) {
@@ -17355,7 +17371,19 @@ ${result2.summary}
     );
   }
   if (dispatch && dispatchAskedFor(dispatch.eventType, "scan")) {
-    await report(dispatch, scoredResult("qScan", result.inventory.readinessScore, result.findings));
+    await report(
+      dispatch,
+      // The pre-baseline findings, deliberately: a repo that baselined
+      // everything must not earn a badge from an empty list. The inventory
+      // rides along, so the platform can say what this repository uses and not
+      // only what is wrong with it.
+      scoredResult(
+        "qScan",
+        result.inventory.readinessScore,
+        result.findings,
+        result.inventory.assets
+      )
+    );
   }
   const gateOpts = { leadMonths: inputs.leadMonths, failNow: inputs.failNow };
   const mandateFailed = mandateEval !== void 0 && mandateGateFails(mandateEval, gateOpts);

--- a/packages/action/src/main.ts
+++ b/packages/action/src/main.ts
@@ -911,7 +911,19 @@ export async function run(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   // readiness 40/100". The mandate gate already refuses to let a baseline waive
   // a deadline for the same reason.
   if (dispatch && dispatchAskedFor(dispatch.eventType, "scan")) {
-    await report(dispatch, scoredResult("qScan", result.inventory.readinessScore, result.findings));
+    await report(
+      dispatch,
+      // The pre-baseline findings, deliberately: a repo that baselined
+      // everything must not earn a badge from an empty list. The inventory
+      // rides along, so the platform can say what this repository uses and not
+      // only what is wrong with it.
+      scoredResult(
+        "qScan",
+        result.inventory.readinessScore,
+        result.findings,
+        result.inventory.assets,
+      ),
+    );
   }
 
   // The two gates OR: a passed compliance deadline fails the build even when

--- a/packages/action/src/platform.ts
+++ b/packages/action/src/platform.ts
@@ -26,6 +26,28 @@ export interface ResultPayload {
   score: number | null;
   summary: string;
   findings: PayloadFinding[];
+  /**
+   * Every algorithm the scan found, safe and unsafe, grouped and posture-classified.
+   *
+   * Sent because "what cryptography do we use" is a different question from
+   * "what is wrong with it", and the platform could only ever answer the second.
+   * A repository that had migrated correctly looked identical to one using no
+   * cryptography at all: both showed nothing and 100/100.
+   *
+   * Absent on a check that has no inventory to report (conformance, probe) and
+   * on any run from a version of the action that predates it, so the platform
+   * has to treat missing and empty as different.
+   */
+  assets?: PayloadAsset[];
+}
+
+/** One algorithm in use, with how much of it there is and a few example sites. */
+export interface PayloadAsset {
+  algorithm: string;
+  kind: string;
+  posture: string;
+  count: number;
+  locations: { file: string; line?: number }[];
 }
 
 export interface PayloadFinding {
@@ -193,6 +215,7 @@ export function scoredResult(
   tool: string,
   score: number | null,
   findings: readonly Parameters<typeof toPayloadFindings>[0][number][],
+  assets?: readonly PayloadAsset[],
 ): Omit<ResultPayload, "auditRunId" | "token"> {
   const n = findings.length;
   return {
@@ -200,6 +223,26 @@ export function scoredResult(
     score,
     summary: `${tool}: ${n} finding(s), readiness ${score ?? "?"}/100`,
     findings: toPayloadFindings(findings),
+    // Capped for the same reason the findings are: this is evidence, not a
+    // dump. An inventory with more distinct algorithms than this is not a
+    // repository, it is a corpus.
+    ...(assets?.length ? { assets: assets.slice(0, MAX_ASSETS).map(toPayloadAsset) } : {}),
+  };
+}
+
+/** Cap on distinct algorithms posted. */
+const MAX_ASSETS = 100;
+
+/** Trim an inventory asset to what the platform renders. */
+function toPayloadAsset(a: PayloadAsset): PayloadAsset {
+  return {
+    algorithm: a.algorithm,
+    kind: a.kind,
+    posture: a.posture,
+    count: a.count,
+    // A few example sites, not every one: the count already carries the scale,
+    // and the locations are only there so a reader can go and look.
+    locations: (a.locations ?? []).slice(0, 5).map((l) => ({ file: l.file, line: l.line })),
   };
 }
 

--- a/packages/action/test/platform.test.ts
+++ b/packages/action/test/platform.test.ts
@@ -375,3 +375,40 @@ test("a finding with no file is sent without a fingerprint rather than a fake on
   const [out] = toPayloadFindings([{ ruleId: "harness/implementation-not-runnable" }]);
   assert.ok(!("fingerprint" in (out ?? {})));
 });
+
+/**
+ * The inventory has to survive the boundary too.
+ *
+ * This is the third field the payload silently dropped, after the remediation
+ * and the fingerprint, and each time the tool knew something the platform could
+ * not say. "What cryptography do we use" is a different question from "what is
+ * wrong with it", and the platform could only ever answer the second.
+ */
+test("scoredResult carries the inventory, capped and trimmed", () => {
+  const assets = [
+    {
+      algorithm: "ML-KEM",
+      kind: "kem",
+      posture: "quantum-safe",
+      count: 94,
+      locations: Array.from({ length: 20 }, (_, i) => ({ file: `a${i}.rs`, line: i })),
+    },
+  ];
+  const r = scoredResult("qScan", 100, [], assets);
+  assert.equal(r.assets?.length, 1);
+  assert.equal(r.assets?.[0]?.count, 94, "the count is the scale and is not truncated");
+  assert.ok(
+    (r.assets?.[0]?.locations.length ?? 0) <= 5,
+    "the locations are evidence, not every site",
+  );
+});
+
+/**
+ * Absent and empty must stay distinguishable: a check with no inventory to
+ * report (conformance, probe) and a run from a version that predates the field
+ * are not the same as "scanned and found no cryptography".
+ */
+test("omits the inventory rather than sending an empty one", () => {
+  assert.ok(!("assets" in scoredResult("qProbe", 97, [])));
+  assert.ok(!("assets" in scoredResult("qScan", 100, [], [])));
+});


### PR DESCRIPTION
Carries the `assets` from quantakrypto/pqc-tools#71 through to the platform.

**The third field this payload has silently dropped**, after `remediation` and the fingerprint. Each time the tool knew something the platform could not say, and each time the boundary is a hand-written object literal that names its fields. Worth a guard of its own eventually.

Capped at 100 distinct algorithms with 5 example sites each. The count carries the scale, so the locations only need to be enough for a reader to go and look. An inventory with more than 100 distinct algorithms is not a repository, it is a corpus.

**Omitted rather than sent empty.** A check with no inventory to report (conformance, probe) and a run from a version predating the field are not the same as "scanned and found no cryptography", and the platform has to tell them apart.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, `dist/` re-bundled. 2 new tests.