### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from 1.0.0.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-14
+
+Minor: additions only. No existing shape changes, no exit code moves, and the
+Action stays on `@v1` because nothing here is breaking.
+
+### Added - a real crypto inventory, not a list of what is wrong
+
+What the tool called an inventory was a findings list under another name.
+`buildInventory` counted findings, `toCbom` iterated findings, and all 47
+detectors fire only on cryptography that is WRONG. `ML-KEM` appeared in the
+entire codebase solely inside remediation strings.
+
+So a repository that had migrated correctly was indistinguishable from one that
+uses no cryptography at all: both reported an empty inventory and 100/100. You
+could prove nothing was broken; you could not prove you had done the work.
+
+`inventory.assets` now carries every algorithm found, grouped with a count and a
+few example sites. The classical half is derived from the findings, which already
+carry algorithm, file and line, so it can never disagree with the findings list.
+The other half is a new pass over PQC families, hybrids, the pre-standard
+CRYSTALS names (kept separate, because a Kyber768 build is not an ML-KEM-768
+build) and the symmetric and hash primitives.
+
+Symmetric is classified `not-quantum-relevant` rather than `quantum-safe`. Grover
+halves the effective key length, which matters at 128 bits and does not break
+256; calling AES quantum-safe beside ML-KEM would flatten a real distinction.
+
+Detection is lexical, like the rest of the engine, so a mention in prose counts.
+Use `--ignore` for content that describes cryptography without using it.
+
+### Added - findings carry their baseline fingerprint
+
+The same id `qscan --write-baseline` writes, so CI and any consumer hold one
+identity for a finding rather than two that agree until one is edited. It
+excludes line and column, so an edit that shifts code down a file does not
+resurface a finding as new.
+
+### Fixed - the JSON reporter dropped the inventory
+
+It names its `inventory` fields explicitly, so `assets` was computed and then
+silently discarded. The third field to be lost at a hand-written boundary, after
+the remediation and the fingerprint.
+
+### Fixed - an algorithm named in key position is not a use of it
+
+`.cargo_vcs_info.json` carries `{"sha1": "<commit>"}` for the git revision, and
+the first inventory run read that as "this project uses SHA-1". A name in key
+position is metadata now. The guard initially also dropped
+`ml_kem_768::keypair()`, because Rust's path separator is a colon too; the tests
+caught it.
+
 ## [0.11.0] - 2026-08-10
 
 Minor: user-facing fixes to the Action, and the runtime it declares. Nothing

--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,13 +2184,13 @@
     },
     "packages/action": {
       "name": "@quantakrypto/action",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.11.0",
-        "@quantakrypto/qprobe": "0.11.0",
-        "@quantakrypto/qscan": "0.11.0",
-        "@quantakrypto/sieve": "0.11.0"
+        "@quantakrypto/core": "0.12.0",
+        "@quantakrypto/qprobe": "0.12.0",
+        "@quantakrypto/qscan": "0.12.0",
+        "@quantakrypto/sieve": "0.12.0"
       },
       "devDependencies": {
         "esbuild": "0.28.1"
@@ -2201,10 +2201,10 @@
     },
     "packages/agent": {
       "name": "@quantakrypto/agent",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.11.0"
+        "@quantakrypto/core": "0.12.0"
       },
       "engines": {
         "node": ">=20"
@@ -2212,7 +2212,7 @@
     },
     "packages/core": {
       "name": "@quantakrypto/core",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -2220,11 +2220,11 @@
     },
     "packages/mcp": {
       "name": "@quantakrypto/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.11.0",
-        "@quantakrypto/qprobe": "0.11.0"
+        "@quantakrypto/core": "0.12.0",
+        "@quantakrypto/qprobe": "0.12.0"
       },
       "bin": {
         "quantakrypto-mcp": "dist/stdio.js"
@@ -2235,10 +2235,10 @@
     },
     "packages/qprobe": {
       "name": "@quantakrypto/qprobe",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/core": "0.11.0"
+        "@quantakrypto/core": "0.12.0"
       },
       "bin": {
         "qprobe": "dist/cli.js"
@@ -2249,11 +2249,11 @@
     },
     "packages/qscan": {
       "name": "@quantakrypto/qscan",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@quantakrypto/agent": "0.11.0",
-        "@quantakrypto/core": "0.11.0"
+        "@quantakrypto/agent": "0.12.0",
+        "@quantakrypto/core": "0.12.0"
       },
       "bin": {
         "qremediate": "dist/remediate-bin.js",
@@ -2265,7 +2265,7 @@
     },
     "packages/sieve": {
       "name": "@quantakrypto/sieve",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "bin": {
         "sieve": "dist/cli.js"

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -26,7 +26,7 @@ var VERSION;
 var init_version = __esm({
   "../core/dist/version.js"() {
     "use strict";
-    VERSION = "0.11.0";
+    VERSION = "0.12.0";
   }
 });
 

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/action",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "quantakrypto Action — fail CI when new quantum-vulnerable cryptography lands. GitHub Action wrapping qScan.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -25,10 +25,10 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.11.0",
-    "@quantakrypto/qprobe": "0.11.0",
-    "@quantakrypto/qscan": "0.11.0",
-    "@quantakrypto/sieve": "0.11.0"
+    "@quantakrypto/core": "0.12.0",
+    "@quantakrypto/qprobe": "0.12.0",
+    "@quantakrypto/qscan": "0.12.0",
+    "@quantakrypto/sieve": "0.12.0"
   },
   "devDependencies": {
     "esbuild": "0.28.1"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/agent",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "BYOK LLM client for qScan triage and remediation. Native fetch, zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.11.0"
+    "@quantakrypto/core": "0.12.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared post-quantum readiness library: crypto detectors, vulnerable-dependency database, inventory + SARIF reporting. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -3,4 +3,4 @@
  * the scan orchestrator can import it without creating a cycle through index.ts.
  * Keep in sync with packages/core/package.json.
  */
-export const VERSION = "0.11.0";
+export const VERSION = "0.12.0";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "mcpName": "io.github.quantakrypto/pqc-tools",
   "description": "quantakrypto MCP — post-quantum readiness for AI coding agents via the Model Context Protocol. Zero runtime dependencies (stdio JSON-RPC implemented in-house).",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.11.0",
-    "@quantakrypto/qprobe": "0.11.0"
+    "@quantakrypto/core": "0.12.0",
+    "@quantakrypto/qprobe": "0.12.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/package.json
+++ b/packages/qprobe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qprobe",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "qProbe — actively inspect live TLS/SSH endpoints you OWN for post-quantum readiness (hybrid KEX, classical certs). Gated behind an ownership attestation. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/core": "0.11.0"
+    "@quantakrypto/core": "0.12.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/qprobe/src/version.ts
+++ b/packages/qprobe/src/version.ts
@@ -6,4 +6,4 @@
  * qProbe JSON report and every endpoint CBOM since 0.8.0 carried toolVersion
  * 0.7.0, which is evidence data, not cosmetics.
  */
-export const VERSION = "0.11.0";
+export const VERSION = "0.12.0";

--- a/packages/qscan/package.json
+++ b/packages/qscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/qscan",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "qScan — find quantum-vulnerable cryptography in any codebase (CLI). Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",
@@ -37,8 +37,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@quantakrypto/agent": "0.11.0",
-    "@quantakrypto/core": "0.11.0"
+    "@quantakrypto/agent": "0.12.0",
+    "@quantakrypto/core": "0.12.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/sieve/package.json
+++ b/packages/sieve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantakrypto/sieve",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Sieve — conformance battery for ML-KEM / ML-DSA implementations. Drives any implementation over a simple stdin/stdout JSON protocol. Zero runtime dependencies.",
   "license": "Apache-2.0",
   "author": "Dandelion Labs <hello@dandelionlabs.io> (https://dandelionlabs.io)",


### PR DESCRIPTION
**Additions only**, so a minor, and the Action stays on `@v1`. Nothing here is breaking, which is exactly the case a moving major tag exists for.

| | |
|---|---|
| **Added** | A real crypto inventory: every algorithm found, safe and unsafe, grouped with counts and example sites. #71 |
| **Added** | Findings carry the baseline fingerprint, the same id `qscan --write-baseline` writes. #70 |
| **Added** | The action sends both through to the platform. #72 |
| **Fixed** | The JSON reporter silently dropped the inventory it had just computed. |
| **Fixed** | An algorithm named in key position (`{"sha1": "<commit>"}`) is metadata, not a use of it. |

## The one worth reading

What the tool called an inventory was a findings list under another name. All 47 detectors fire only on cryptography that is *wrong*, so a repository that had migrated to ML-KEM was **indistinguishable from one using no cryptography at all**: both reported an empty inventory and 100/100. You could prove nothing was broken; you could not prove you had done the work.

Verified against QuantaCipher's published core: **5 Kyber (pre-standard), 6 AES-256, and correctly no ML-KEM** — the audit finding we sent them, rendered as an inventory rather than a complaint.

## Verification

`npm run build`, `npm test`, `npm run lint`, `npm run format:check`, plus every release gate: `check-zero-deps`, `check-action-yml-sync`, `check-example-workflows`, `api:check`, `repro:check` (all 6 reproducible). `dist/` re-bundled.

Merging does not publish. Publishing the `v0.12.0` Release runs `release.yml`, which publishes the six public packages with provenance and moves `v1`.