### PR TITLE
ci: pin every codeql-action step to v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/init@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+      - uses: github/codeql-action/analyze@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 7
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Supersedes #69, which cannot pass on its own.

## Why Dependabot can't do this one

Dependabot opens one PR per action path, so `init` and `analyze` move independently. CodeQL requires them to be the **exact same version**, not merely the same major.

Merging #68 took `init` to v4.37.6 while `analyze` stayed on v3.28.1. #69 then failed with:

```
Loaded a configuration file for version '4.37.6', but running version '4.37.7'
```

because by the time Dependabot recreated it, the target had moved again. Neither PR can be green while the other is open, in either merge order. This is structural, not a one-off.

## What this does

All three uses go to v4.37.7 in one commit:

| File | Step | Was |
|---|---|---|
| `codeql.yml` | `init` | v4.37.6 |
| `codeql.yml` | `analyze` | v3.28.1 |
| `scorecard.yml` | `upload-sarif` | v4.37.6 |

`upload-sarif` was on the same stale pin and would have drifted next. Keeping all three on one line makes the next bump one decision rather than a race between three PRs.

Note that CodeQL was passing on `main` despite the v4/v3 split, so this is consistency and future-proofing, not an outage fix.