### PR TITLE
deps: bump prettier to 3.9.6 and apply its formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "^26.2.0",
         "eslint": "^9.18.0",
         "fast-check": "^4.9.0",
-        "prettier": "^3.4.2",
+        "prettier": "^3.9.6",
         "tsx": "^4.23.1",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.67.0"
@@ -1912,9 +1912,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^26.2.0",
     "eslint": "^9.18.0",
     "fast-check": "^4.9.0",
-    "prettier": "^3.4.2",
+    "prettier": "^3.9.6",
     "tsx": "^4.23.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.67.0"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,16 +25,7 @@ export type FindingCategory =
 
 /** Classical asymmetric algorithm families that are not quantum-safe. */
 export type AlgorithmFamily =
-  | "RSA"
-  | "ECDH"
-  | "ECDSA"
-  | "EdDSA"
-  | "DH"
-  | "DSA"
-  | "X25519"
-  | "X448"
-  | "ECIES"
-  | "unknown";
+  "RSA" | "ECDH" | "ECDSA" | "EdDSA" | "DH" | "DSA" | "X25519" | "X448" | "ECIES" | "unknown";
 
 /** A precise location inside a scanned file. */
 export interface SourceLocation {
@@ -96,14 +87,7 @@ export interface Finding {
 
 /** Package ecosystems the dependency scanner understands. */
 export type DependencyEcosystem =
-  | "npm"
-  | "pypi"
-  | "cargo"
-  | "go"
-  | "maven"
-  | "rubygems"
-  | "nuget"
-  | "composer";
+  "npm" | "pypi" | "cargo" | "go" | "maven" | "rubygems" | "nuget" | "composer";
 
 /** A known quantum-vulnerable dependency entry. */
 export interface VulnerableDependency {

--- a/packages/sieve/src/categories/correctness.ts
+++ b/packages/sieve/src/categories/correctness.ts
@@ -24,9 +24,7 @@ import { toB64 } from "../protocol.js";
 
 /** Outcome of one round-trip iteration. */
 type Outcome =
-  | { kind: "ok" }
-  | { kind: "mismatch"; detail: string }
-  | { kind: "error"; detail: string };
+  { kind: "ok" } | { kind: "mismatch"; detail: string } | { kind: "error"; detail: string };
 
 export const correctness: Category = async (ctx): Promise<CategoryResult> => {
   const checks: Check[] = [];

--- a/packages/sieve/src/protocol.ts
+++ b/packages/sieve/src/protocol.ts
@@ -164,12 +164,7 @@ interface ErrorResult {
 
 /** Any response the SUT may emit. */
 export type Response =
-  | KeygenResult
-  | EncapsResult
-  | DecapsResult
-  | SignResult
-  | VerifyResult
-  | ErrorResult;
+  KeygenResult | EncapsResult | DecapsResult | SignResult | VerifyResult | ErrorResult;
 
 // ---------------------------------------------------------------------------
 // Serialization


### PR DESCRIPTION
Replaces #25, which sat conflicting long enough that Dependabot could no longer rebase it.

## The version bump is nearly a no-op

`package.json` already carried `"prettier": "^3.4.2"`, so any fresh install inside that range was already resolving to 3.9. Only the lockfile floor was stale.

## The formatting is not

Prettier 3.9 keeps a short union on one line rather than breaking every member onto its own. Three files change:

- `packages/core/src/types.ts`
- `packages/sieve/src/categories/correctness.ts`
- `packages/sieve/src/protocol.ts`

They are reformatted **in this commit**, deliberately. Bumping the version without them would land a `main` that fails its own `format:check` job.

## Verified locally

| | |
|---|---|
| `npm run lint` | clean |
| `npm run build` | clean |
| `npm test` | 33 passing |
| `npm run format:check` | clean after the reformat |