### PR TITLE
deps: move to TypeScript 6 and declare the node types explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "fast-check": "^4.9.0",
         "prettier": "^3.9.6",
         "tsx": "^4.23.1",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.67.0"
       },
       "engines": {
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fast-check": "^4.9.0",
     "prettier": "^3.9.6",
     "tsx": "^4.23.1",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.67.0"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": false,
     "noImplicitOverride": true,
     "isolatedModules": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
Replaces #45, which failed every job with **325** copies of:

```
TS2591: Cannot find name 'node:child_process'. Do you need to install type
definitions for node? Try `npm i --save-dev @types/node` ...
```

on ordinary `import { execFile } from "node:child_process"` lines, with `@types/node` installed the whole time. The suggestion in the error was right, just not for the reason it implies.

## Cause

TypeScript 6 no longer sweeps every `@types` package in `node_modules` into the global scope automatically. This repo depended on that: `tsconfig.base.json` had no `types` field at all.

Naming `node` restores it. One line, 325 errors to zero:

```diff
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
```

## The restriction is the point

Automatic inclusion was also dragging in `@types/esrecurse`, `@types/estree` and `@types/json-schema` — all transitive through eslint, none of them meant to be global. `@types/node` is the only `@types` package this repo actually declares.

## Verified locally on 6.0.3

| | |
|---|---|
| `npm run build` | clean |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm test` | **1,354 passing** across all eight suites |